### PR TITLE
Add a skip-to-main content link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This app allows the user to explore HMLR price-paid open
 linked data.
 
+## 1.3.1 - 2020-09-22 (Ian)
+
+- added a skip-to-main-content link for keyboard navigation
+
 ## 1.3.0 - 2020-09-20 (Ian)
 
 - A collection of WCAG fixes under GH-117. Pending manual testing,

--- a/Gemfile
+++ b/Gemfile
@@ -51,10 +51,11 @@ gem 'faraday'
 gem 'faraday_middleware'
 gem 'font-awesome-rails'
 gem 'jquery-ui-rails'
+gem 'sentry-raven'
+gem 'yajl-ruby', require: 'yajl'
+
 gem 'lr_common_styles', git: 'https://github.com/epimorphics/lr_common_styles.git'
 # gem 'lr_common_styles', path: '/home/ian/projects/hmlr/lr_common_styles'
-gem 'yajl-ruby', require: 'yajl'
-gem 'sentry-raven'
 
 group :test do
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,9 @@ GIT
       json
       yajl-ruby
 
-PATH
-  remote: /home/ian/projects/hmlr/lr_common_styles
+GIT
+  remote: https://github.com/epimorphics/lr_common_styles.git
+  revision: 3f14efcc2d6c806b77b5e1c91fa567fe3aa6e94d
   specs:
     lr_common_styles (1.6.0)
       bootstrap-sass (~> 3.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,11 +7,10 @@ GIT
       json
       yajl-ruby
 
-GIT
-  remote: https://github.com/epimorphics/lr_common_styles.git
-  revision: 9ed1936bf3ece3aadc2d3a80ae8bf4961407fdd2
+PATH
+  remote: /home/ian/projects/hmlr/lr_common_styles
   specs:
-    lr_common_styles (1.5.0)
+    lr_common_styles (1.6.0)
       bootstrap-sass (~> 3.4.0)
       font-awesome-rails (~> 4.7.0.1)
       govuk_elements_rails (~> 2.0.0)

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 module Version
   MAJOR = 1
   MINOR = 3
-  REVISION = 0
+  REVISION = 1
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
 end


### PR DESCRIPTION
Support keyboard navigation by adding a skip-to-main-content link
