### PR TITLE
Replace jQuery datepicker with native HTML controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This app allows the user to explore HMLR price-paid open
 linked data.
 
+## 1.4.0 - 2020-09-22 (Ian)
+
+- switched from JQuery datePicker component to use browser date
+  input controls
+
 ## 1.3.1 - 2020-09-22 (Ian)
 
 - added a skip-to-main-content link for keyboard navigation

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,5 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require jquery-ui/widgets/datepicker
 //= require bootstrap
 //= require_tree .

--- a/app/assets/javascripts/ppd.js
+++ b/app/assets/javascripts/ppd.js
@@ -9,15 +9,6 @@ var Ppd = function() {
   };
 
   var initControls = function() {
-    $(".date-picker").datepicker( {
-      dateFormat: "d MM yy",
-      changeMonth: true,
-      changeYear: true,
-      onChangeMonthYear: onChangeMonthYear,
-      minDate: new Date( 1995, 0, 1 ),
-      maxDate: new Date()
-    } );
-
     $(".js.hidden").removeClass("hidden");
 
     // ajax spinner
@@ -42,27 +33,6 @@ var Ppd = function() {
 
     $(document).on( "ajaxSend", onAjaxSend )
                .on( "ajaxComplete", onAjaxComplete );
-  };
-
-  var onChangeMonthYear = function( year, month, dp ) {
-    var control_name = $(this).attr( "name" );
-    var defaultDate = defaultDayOfMonth( year, month, control_name );
-    $(this).datepicker( "setDate", defaultDate );
-  };
-
-  var defaultDays = {
-    min_date: {
-      1: 1, 2: 1, 3: 1, 4:  1,  5: 1,  6: 1,
-      7: 1, 8: 1, 9: 1, 10: 1, 11: 1, 12: 1
-    },
-    max_date: {
-      1: 31, 2: 28, 3: 31, 4:  30,  5: 31,  6: 30,
-      7: 31, 8: 31, 9: 30, 10: 31, 11: 30, 12: 31
-    }
-  };
-
-  var defaultDayOfMonth = function( year, month, name ) {
-    return new Date( year, month - 1, defaultDays[name][month] );
   };
 
   var validateAmount = function( selector ) {
@@ -140,8 +110,6 @@ var Ppd = function() {
     e.preventDefault();
     $("#help-modal").modal("show");
   };
-
-
 
   /* Ajax event handling */
   var onAjaxSend = function( e ) {

--- a/app/assets/stylesheets/ppd.scss
+++ b/app/assets/stylesheets/ppd.scss
@@ -139,10 +139,6 @@
     padding-top: 3px;
   }
 
-  #ui-datepicker-div {
-    z-index: 10 !important;
-  }
-
   .search-limit-reached {
     margin: 10px 0;
     padding: 8px;

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -2,7 +2,7 @@
 
 module Version
   MAJOR = 1
-  MINOR = 3
-  REVISION = 1
+  MINOR = 4
+  REVISION = 0
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
 end

--- a/app/views/ppd/index.html.haml
+++ b/app/views/ppd/index.html.haml
@@ -142,19 +142,19 @@
                 Please enter a valid numerical value, or leave blank
 
       .form-group
-        %label.col-sm-4.control-label.control-label-adjust{ for: "date" } Date
+        %label.col-sm-4.control-label.control-label-adjust{ for: 'date' } Date
         .col-sm-8
           %ul.list-inline
             %li
               %div
                 %label
                   earliest:
-                  %input.date-picker{ type: "text", name: :min_date, value: @preferences.param( :min_date ) }
+                  %input{ type: 'date', name: :min_date, value: @preferences.param( :min_date ), min: "1995-01-01", max: Date.today.iso8601 }
             %li
               %div
                 %label
                   latest:
-                  %input.date-picker{ type: "text", name: :max_date, value: @preferences.param( :max_date ) }
+                  %input{ type: 'date', name: :max_date, value: @preferences.param( :max_date ), min: "1995-01-01", max: Date.today.iso8601 }
 
       .form-group
         %label.col-sm-4.control-label{ for: "limit" } How many results?


### PR DESCRIPTION
This PR removes the jQuery datepicker elements we had been using, since they cause problems with WCAG compliance (specifically, keyboard navigation). Instead, we rely on native HTML date picker elements, since these are now widely supported.