### PR TITLE
Switch from Travis to GH actions

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,0 +1,21 @@
+name: Rails CI test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+    - name: Install dependencies
+      run: bundle install
+    - name: Run rubocop
+      run: bundle exec rubocop
+    - name: Run tests
+      run: bundle exec rails test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,9 +2,10 @@ AllCops:
   TargetRubyVersion: 2.4
   Exclude:
     - 'node_modules/**/*'
+  NewCops: enable
 
 # Customize rules
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
   Exclude:
     - bin/**/*
@@ -30,3 +31,13 @@ Style/FormatStringToken:
 Style/Documentation:
   Exclude:
     - test/**/*
+
+Style/OptionalBooleanParameter:
+  Enabled: false
+
+Lint/ConstantDefinitionInBlock:
+  Exclude:
+    - test/**/*
+
+Lint/DuplicateBranch:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-rvm:
-  - 2.6
-script: bundle exec rake test
-before_install:
-  - gem install bundler -v 2.0.2
-  - yarn install

--- a/Gemfile
+++ b/Gemfile
@@ -19,18 +19,12 @@ gem 'therubyracer', platforms: :ruby
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
-
-# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-# gem 'turbolinks'
-
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder'
 
 gem 'bootstrap-sass'
 gem 'haml-rails'
 
 group :doc do
-  # bundle exec rake doc:rails generates the API under doc/api.
   gem 'sdoc', require: false
 end
 
@@ -38,7 +32,6 @@ gem 'byebug', group: %i[development test]
 
 group :development do
   gem 'rb-readline'
-  # gem 'quiet_assets'
 
   gem 'flamegraph'
   gem 'memory_profiler'
@@ -63,7 +56,6 @@ group :test do
   gem 'capybara'
   gem 'capybara_minitest_spec'
   gem 'capybara-selenium'
-  # gem 'chromedriver-helper'
   gem 'json_expressions'
   gem 'minitest-rails'
   gem 'minitest-reporters'

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ group :development do
   gem 'flamegraph'
   gem 'memory_profiler'
   gem 'stackprof' # ruby 2.1+ only
+  gem 'rubocop'
+  gem 'rubocop-rails'
 end
 
 gem 'data_services_api', git: 'https://github.com/epimorphics/ds-api-ruby.git'

--- a/Gemfile
+++ b/Gemfile
@@ -42,9 +42,9 @@ group :development do
 
   gem 'flamegraph'
   gem 'memory_profiler'
-  gem 'stackprof' # ruby 2.1+ only
   gem 'rubocop'
   gem 'rubocop-rails'
+  gem 'stackprof' # ruby 2.1+ only
 end
 
 gem 'data_services_api', git: 'https://github.com/epimorphics/ds-api-ruby.git'
@@ -61,8 +61,8 @@ gem 'lr_common_styles', git: 'https://github.com/epimorphics/lr_common_styles.gi
 
 group :test do
   gem 'capybara'
-  gem 'capybara-selenium'
   gem 'capybara_minitest_spec'
+  gem 'capybara-selenium'
   # gem 'chromedriver-helper'
   gem 'json_expressions'
   gem 'minitest-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
     arel (9.0.0)
+    ast (2.4.2)
     autoprefixer-rails (10.0.1.0)
       execjs
     bootstrap-sass (3.4.1)
@@ -189,6 +190,9 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    parallel (1.20.1)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
     public_suffix (4.0.6)
     puma (5.0.2)
       nio4r (~> 2.0)
@@ -219,6 +223,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    rainbow (3.0.0)
     rake (13.0.1)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
@@ -227,6 +232,22 @@ GEM
     rdoc (6.2.1)
     ref (2.0.0)
     regexp_parser (1.8.1)
+    rexml (3.2.4)
+    rubocop (1.10.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    rubocop-rails (2.9.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.90.0, < 2.0)
     ruby-progressbar (1.10.1)
     ruby_parser (3.15.0)
       sexp_processor (~> 4.9)
@@ -275,6 +296,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    unicode-display_width (2.0.0)
     vcr (6.0.0)
     webdrivers (4.4.1)
       nokogiri (~> 1.6)
@@ -320,6 +342,8 @@ DEPENDENCIES
   puma
   rails (< 6.0.0)
   rb-readline
+  rubocop
+  rubocop-rails
   sass-rails
   sdoc
   sentry-raven

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,8 +20,8 @@ class ApplicationController < ActionController::Base
   end
 
   unless Rails.application.config.consider_all_requests_local
-    rescue_from ActionController::RoutingError, with: :render_404
-    rescue_from ActionController::InvalidCrossOriginRequest, with: :render_403
+    rescue_from ActionController::RoutingError, with: :render404
+    rescue_from ActionController::InvalidCrossOriginRequest, with: :render403
     rescue_from Exception, with: :render_exception
   end
 
@@ -38,11 +38,11 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def render_404(_exception = nil)
+  def render404(_exception = nil)
     render_error(404)
   end
 
-  def render_403(_exception = nil)
+  def render403(_exception = nil)
     render_error(403)
   end
 

--- a/app/controllers/concerns/dsapi_turtle_formatter.rb
+++ b/app/controllers/concerns/dsapi_turtle_formatter.rb
@@ -39,7 +39,7 @@ module DsapiTurtleFormatter
   def format_ttl_value(value)
     f =
       if value.is_a?(Array)
-        value.map { |v0| format_ttl_value v0 } .join(', ')
+        value.map { |v0| format_ttl_value v0 }.join(', ')
       elsif value.is_a? Numeric
         value.to_s
       elsif value.match?(%r{\Ahttp://.*})

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,8 +6,7 @@ class SearchController < ApplicationController
     create
   end
 
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-  # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/MethodLength
   def create
     @preferences = UserPreferences.new(params)
 
@@ -34,9 +33,8 @@ class SearchController < ApplicationController
 
     render_error_page(e, e.message, status)
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
-  # rubocop:enable Metrics/PerceivedComplexity
 
+  # rubocop:enable Metrics/MethodLength
   def use_compact_json?
     !non_compact_formats.include?(request.format)
   end

--- a/app/helpers/ppd_helper.rb
+++ b/app/helpers/ppd_helper.rb
@@ -10,7 +10,7 @@ module PpdHelper
     end
   end
 
-  def address_detail_filter(aspect, result, preferences) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+  def address_detail_filter(aspect, result, preferences) # rubocop:disable Metrics/MethodLength
     vp = result.presentation_value_of_property(aspect.aspect_key_property)
     val = result.value_of_property(aspect.aspect_key_property)
 

--- a/app/lib/auto_extend_hash.rb
+++ b/app/lib/auto_extend_hash.rb
@@ -14,7 +14,7 @@ class AutoExtendHash < Hash
     return unless hash.is_a?(Hash)
 
     conditionally_set_default_proc(hash)
-    hash.values.each { |value| AutoExtendHash.auto_extend(value) }
+    hash.each_value { |value| AutoExtendHash.auto_extend(value) }
   end
 
   def auto_extending_hash(hash, key)

--- a/app/models/aspect.rb
+++ b/app/models/aspect.rb
@@ -96,6 +96,6 @@ class Aspect
 
   # Return true if all of the given aspect valukes are present
   def all_present?(values, preferences)
-    values.map { |v| preferences.present?(key, v) } .inject(&:&)
+    values.map { |v| preferences.present?(key, v) }.inject(&:&)
   end
 end

--- a/app/models/concerns/turtle_formatter.rb
+++ b/app/models/concerns/turtle_formatter.rb
@@ -11,7 +11,7 @@ module TurtleFormatter
     ttl_value = { properties: [] }
 
     result.map do |property, value|
-      next if value.respond_to?(:'empty?') && value.empty?
+      next if value.respond_to?(:empty?) && value.empty?
 
       if property == '@id'
         ttl_value[:uri] = format_ttl_value(value)
@@ -31,12 +31,12 @@ module TurtleFormatter
       if value.nil?
         ''
       elsif value.is_a?(Array)
-        value.map { |v| format_ttl_value(v) } .join(', ')
+        value.map { |v| format_ttl_value(v) }.join(', ')
       elsif value.is_a? Numeric
         value.to_s
-      elsif value.respond_to?(:'match?') && value.match?(%r{\Ahttp://.*})
+      elsif value.respond_to?(:match?) && value.match?(%r{\Ahttp://.*})
         "<#{value}>"
-      elsif value.respond_to?(:'match?') && value.match?(/\A[[:word:]]+:.*/)
+      elsif value.respond_to?(:match?) && value.match?(/\A[[:word:]]+:.*/)
         value.to_s
       elsif [false, true].include?(value)
         value.to_s

--- a/app/models/paon.rb
+++ b/app/models/paon.rb
@@ -61,7 +61,7 @@ class Paon < String # rubocop:disable Metrics/ClassLength
   # private
 
   def elements(paon)
-    components = paon.match?(/\A *(\d+[A-Z]*) *\- *(\d+[A-Z]*) *\Z/) ? paon.split('-') : [paon]
+    components = paon.match?(/\A *(\d+[A-Z]*) *- *(\d+[A-Z]*) *\Z/) ? paon.split('-') : [paon]
     components.map { |p| parse_paon(p) }
   end
 

--- a/app/models/query_command.rb
+++ b/app/models/query_command.rb
@@ -5,6 +5,7 @@ class QueryCommand < DataService # rubocop:disable Metrics/ClassLength
   include TurtleFormatter
 
   attr_reader :all_results, :search_results, :error_message
+
   COUNT_LIMIT = 10_000
 
   ASPECTS = {

--- a/app/models/search_aspect.rb
+++ b/app/models/search_aspect.rb
@@ -36,7 +36,7 @@ class SearchAspect < Aspect
   # Sanitise input and convert to Lucene expression
   def text_index_term(preferences) # rubocop:disable Metrics/MethodLength
     terms = sanitise_punctuation(preference_value(preferences))
-            .split(' ')
+            .split
             .reject { |token| LUCENE_KEYWORDS.include?(token.downcase) }
             .reject(&:empty?)
 

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -163,9 +163,10 @@ class SearchResult # rubocop:disable Metrics/ClassLength
   def update_value_for_property(obj, prop, value)
     target = obj.key?(prop) && obj[prop]
 
-    if target&.is_a?(Array)
+    case target
+    when Array
       update_value_array(target, value)
-    elsif target&.is_a?(Hash)
+    when Hash
       target['@value'] = value
     else
       obj[prop] = value
@@ -239,7 +240,7 @@ class SearchResult # rubocop:disable Metrics/ClassLength
   end
 
   def format_paon_elements(paon)
-    paon.split(' ').map do |token|
+    paon.split.map do |token|
       case token
       when /\d/
         token

--- a/config.ru
+++ b/config.ru
@@ -2,5 +2,5 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment', __FILE__)
+require ::File.expand_path('config/environment', __dir__)
 run Rails.application

--- a/test/controllers/ppd_data_controller_test.rb
+++ b/test/controllers/ppd_data_controller_test.rb
@@ -11,15 +11,15 @@ class PpdDataControllerTest < ActionDispatch::IntegrationTest
   describe 'PpdDataController' do
     let(:base_params) do
       {
-        'et': ['lrcommon:freehold', 'lrcommon:leasehold'],
-        'limit': 100,
-        'min_date': '1 January 2016',
-        'max_date': '31 January 2016',
-        'nb': [true, false],
-        'ptype': ['lrcommon:detached', 'lrcommon:semi-detached', 'lrcommon:terraced',
-                  'lrcommon:flat-maisonette', 'lrcommon:otherPropertyType'],
-        'tc': ['ppd:standardPricePaidTransaction', 'ppd:additionalPricePaidTransaction'],
-        'town': 'glastonbury'
+        et: ['lrcommon:freehold', 'lrcommon:leasehold'],
+        limit: 100,
+        min_date: '1 January 2016',
+        max_date: '31 January 2016',
+        nb: [true, false],
+        ptype: ['lrcommon:detached', 'lrcommon:semi-detached', 'lrcommon:terraced',
+                'lrcommon:flat-maisonette', 'lrcommon:otherPropertyType'],
+        tc: ['ppd:standardPricePaidTransaction', 'ppd:additionalPricePaidTransaction'],
+        town: 'glastonbury'
       }
     end
 


### PR DESCRIPTION
Switching from Travis to Github actions for CI. This also entailed getting the Rubocop checks to a point where they were all passing, including newly added Cops.

- Switch from Travis to GH Actions for CI
- Add missing Rubocop dependencies
- Fix Rubocop warnings
