### PR TITLE
Correct setting relative url root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN bundle install
 # Set environment variables and expose the running port
 ENV RAILS_ENV="production"
 ENV RAILS_SERVE_STATIC_FILES="true"
-ENV RELATIVE_URL_ROOT="/app/ppd"
+ENV RAILS_RELATIVE_URL_ROOT="/app/ppd"
 ENV SCRIPT_NAME="/app/ppd"
 ENV API_SERVICE_URL="http://localhost:8080"
 EXPOSE 3000

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,8 +85,7 @@ PpdExplorer::Application.configure do
   # config.log_formatter = ::Logger::Formatter.new
 
   # Specify that we're not at the root
-  config.action_controller.relative_url_root = ENV['RELATIVE_URL_ROOT'] || '/'
-  config.relative_url_root = ENV['RELATIVE_URL_ROOT'] || '/'
+  config.relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT'] || '/'
 
   # API location can be specified in the environment
   # But defaults to the dev service


### PR DESCRIPTION
We are currently using an environment variable with the name 'RELATIVE_URL_ROOT' but the correct convention is to use
'RAILS_RELATIVE_URL_ROOT' which has the added effect of setting the config.application_controller.relative_url_root for us
automatically.

This PR addresses epimorphics/hmlr-linked-data#69 (I hope)
