### PR TITLE
Fix for log messages not writing to stdout

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,8 +8,7 @@ class SearchController < ApplicationController
     create
   end
 
-  # rubocop:disable Metrics/MethodLength
-  def create
+  def create # rubocop:disable Metrics/MethodLength
     @preferences = UserPreferences.new(params)
 
     if @preferences.empty?
@@ -36,7 +35,6 @@ class SearchController < ApplicationController
     render_error_page(e, e.message, status)
   end
 
-  # rubocop:enable Metrics/MethodLength
   def use_compact_json?
     !non_compact_formats.include?(request.format)
   end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -5,12 +5,3 @@ require File.expand_path('application', __dir__)
 
 # Initialize the Rails application.
 PpdExplorer::Application.initialize!
-
-# Custom logger
-logger = ActiveSupport::Logger.new("log/#{Rails.env}.log")
-logger.formatter = proc do |severity, time, _prog_name, msg|
-  msg_without_time = msg.gsub(/ at [0-9 :+\-]*/, '')
-  msg_one_line = msg_without_time.gsub(/\n/, '\n')
-  "#{severity} #{time.iso8601(3)} #{msg_one_line}\n"
-end
-Rails.logger = ActiveSupport::TaggedLogging.new(logger)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,6 +55,7 @@ PpdExplorer::Application.configure do
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new)
+  $stdout.sync = true
   config.logger = JsonRailsLogger::Logger.new($stdout)
 
   # Use a different cache store in production.


### PR DESCRIPTION
epimorphics/hmlr-linked-data#76
This commit fixes a problem that log messages from PPD running in
production mode were not being written to `stdout`, despite loading the
JsonRailsLogger.

The problem was a legacy configuration for a logger in `environment.rb`,
which was overriding the assignment of `JsonRailsLogger`.
