### PR TITLE
Fix for SPARQL query redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This app allows the user to explore HMLR price-paid open
 linked data.
 
+## 1.5.1 - 2022-01-28
+
+- (Joseph) Change to as SPARQL query redirect url
+
 ## 1.5.0 - 2022-01-10
 
 - (Mairead) Update deployment workflow, dockerfile and assisting scripts

--- a/app/controllers/ppd_data_controller.rb
+++ b/app/controllers/ppd_data_controller.rb
@@ -54,7 +54,7 @@ class PpdDataController < ApplicationController
 
   def show_sparql_explanation(preferences)
     explanation = ExplainCommand.new(preferences).load_explanation
-    redirect_to "/app/hpi/qonsole?q=#{URI.encode_www_form_component(explanation[:sparql])}"
+    redirect_to "/app/qonsole?q=#{URI.encode_www_form_component(explanation[:sparql])}"
   end
 
   def download_data(preferences)

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,6 @@
 module Version
   MAJOR = 1
   MINOR = 5
-  REVISION = 0
+  REVISION = 1
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
 end


### PR DESCRIPTION
Addresses epimorphics/hmlr-linked-data#86. The current route for the SPARQL query redirect to qonsole was returning with 404
because that routing alias is not configured in the proxy. It looks to me however that this piece of the URL is
not necessary for it to work, suggest we remove it unless there is some known reason to have two routes to the same end.﻿
