### PR TITLE
Add support for monitoring with Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This app allows the user to explore HMLR price-paid open
 linked data.
 
+## 1.6.0 - 2022-01-31
+
+- (Ian) Added Prometheus metrics for observability in production
+
 ## 1.5.0 - 2022-01-10
 
 - (Mairead) Update deployment workflow, dockerfile and assisting scripts

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,9 @@ gem 'data_services_api', git: 'https://github.com/epimorphics/ds-api-ruby.git', 
 gem 'faraday'
 gem 'faraday_middleware'
 gem 'font-awesome-rails'
+gem 'get_process_mem'
 gem 'jquery-ui-rails'
+gem 'prometheus-client'
 gem 'sentry-raven'
 gem 'yajl-ruby', require: 'yajl'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/epimorphics/ds-api-ruby.git
-  revision: 08025dd6dcd54defffc148f46ee92980b8f841ba
+  revision: 86c0aadc15f064cfbc6352aca7065e0e93abd97c
   branch: task/infrastructure-update
   specs:
     data_services_api (1.1.0)
@@ -116,31 +116,37 @@ GEM
     erubi (1.10.0)
     erubis (2.7.0)
     execjs (2.7.0)
-    faraday (1.8.0)
+    faraday (1.9.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
       faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.1)
+      faraday-net_http_persistent (~> 1.0)
       faraday-patron (~> 1.0)
       faraday-rack (~> 1.0)
-      multipart-post (>= 1.2, < 3)
+      faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.3)
+      multipart-post (>= 1.2, < 3)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     ffi (1.15.4)
     flamegraph (0.9.5)
     font-awesome-rails (4.7.0.7)
       railties (>= 3.2, < 7)
+    get_process_mem (0.2.7)
+      ffi (~> 1.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     govuk_elements_rails (2.0.0)
@@ -235,6 +241,7 @@ GEM
     parallel (1.21.0)
     parser (3.0.3.2)
       ast (~> 2.4.1)
+    prometheus-client (2.1.0)
     public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
@@ -376,6 +383,7 @@ DEPENDENCIES
   faraday_middleware
   flamegraph
   font-awesome-rails
+  get_process_mem
   haml-rails
   jbuilder
   jquery-rails
@@ -390,6 +398,7 @@ DEPENDENCIES
   minitest-spec-rails
   minitest-vcr
   mocha
+  prometheus-client
   puma
   rails (< 6.0.0)
   rb-readline
@@ -407,4 +416,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.2.33
+   2.3.5

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ which the DS-API is available on `localhost:8080`. In development,
 the script `bin/sr-tunnel-daemon` can be used to simulate that
 environment, using ssh to proxy the remote dev API onto `localhost`.
 
+### Coding standards
+
+Rubocop should always return no errors or warnings.
+
+### Running the tests
+
+```sh
+rails -t
+```
+
 ## Deployment
 
 To mimic running the application in a deployed state you can run
@@ -35,17 +45,75 @@ To bypass the need for running locally AWS you can pass a global variable to the
 
 You can run `make help` to view a list of other make commands available
 
-## Entrypoint.sh
+### entrypoint.sh
 
-* The Rails Framework requires certain values to be set as a Global environment variable when starting. To ensure the `RAILS_RELATIVE_URL_ROOT` is only set in one place per application we have added this to the Entrypoint file along with the `SCRIPT_NAME`.
-* The Rails secret is also created here.
-* There is a workaround to removing the PID lock of the Rails process in the event of the application crashing and not releasing the process.
-* We have to pass the `API_SERVICE_URL` so that it is available in the Entrypoint.sh or the application will throw an error and exit before starting
+This script is used as the main entry point for starting the app from the `Dockerfile`.
 
-### Coding standards
+The Rails Framework requires certain values to be set as a Global environment variable
+when starting. To ensure the `RAILS_RELATIVE_URL_ROOT` is only set in one place per
+application we have added this to the `entrypoint.sh` file along with the `SCRIPT_NAME`.
+The Rails secret is also created here.
 
-Rubocop should always return no errors or warnings.
+There is a workaround to removing the PID lock of the Rails process in the event of
+the application crashing and not releasing the process.
 
-### Running the tests
+We have to pass the `API_SERVICE_URL` so that it is available in the `entrypoint.sh`
+or the application will throw an error and exit before starting
 
-    rails -t
+### Prometheus monitoring
+
+[Prometheus](https://prometheus.io) is set up to provide metrics on the
+`/metrics` endpoint. The following metrics are recorded:
+
+- `data_api_status` (counter)
+  Response from data API
+- `data_api_connection_failure` (counter)
+  Could not connect to back-end data API'
+- `data_api_service_exception` (counter)
+  The response from the back-end data API was not processed'
+- `internal_application_error` (counter)
+  Unexpected events and internal error count
+- `memory_used_mb` (gauge)
+  Process memory usage in megabytes
+
+Internally, we use ActiveSupport Notifications to emit events which are
+monitored and collected by the Prometheus store. Relevant pieces of the
+app include:
+
+- `app/lib/prometheus/metrics.rb`
+  A central register where metrics can be stored and looked-up subsequently
+  by use of a symbol key.
+- `config/initializers/prometheus.rb`
+  Defines the Prometheus counters that the app knows about, and registers them
+  in the metrics store (see above)
+- `config/initializers/load_notification_subscribers.rb`
+  Some boiler-plate code to ensure that all of the notification subscribers
+  are loaded when the app starts
+- `app/subscribers`
+  Folder where the subscribers to the known ActiveSupport notifications are
+  defined. This is where the transform from `ActiveSupport::Notification` to
+  Prometheus counter or gauge is performed.
+
+In addition to the metrics we define, there is a collection of standard
+metrics provided automatically by the
+[Ruby Prometheus client](https://github.com/prometheus/client_ruby)
+
+To test Prometheus when developing locally, there needs to be a Prometheus
+server running. Tip for Linux users: do not install the Prometheus apt
+package. This starts a locally running daemon with a pre-defined
+configuration, which is useful when monitoring the machine on which the
+server is running. A better approach for testing Prometheus is to
+[download](https://prometheus.io/download/) the server package and
+run it locally, with a suitable configuration. A basic config for
+monitoring a Rails application is provided in `test/prometheus/dev.yml`.
+
+Using this approach, and assuming you install your local copy of
+Prometheus into `~/apps`, a starting command line would be something like:
+
+```sh
+~/apps/prometheus/prometheus-2.32.1.linux-amd64/prometheus \
+  --config.file=test/prometheus/dev.yml \
+  --storage.tsdb.path=./tmp/metrics2
+```
+
+Something roughly equivalent should be possible on Windows and Mac as well.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,8 +25,6 @@ class ApplicationController < ActionController::Base
     rescue_from Exception, with: :render_exception
   end
 
-  private
-
   def render_exception(exception)
     if exception.instance_of? ArgumentError
       render_error(400)
@@ -34,15 +32,16 @@ class ApplicationController < ActionController::Base
       render_error(403)
     else
       Rails.logger.warn "No explicit error page for exception #{exception} - #{exception.class}"
+      instrument_internal_error(exception)
       render_error(500)
     end
   end
 
-  def render404(_exception = nil)
+  def render_404(_exception = nil) # rubocop:disable Naming/VariableNumber
     render_error(404)
   end
 
-  def render403(_exception = nil)
+  def render_403(_exception = nil) # rubocop:disable Naming/VariableNumber
     render_error(403)
   end
 
@@ -82,5 +81,9 @@ class ApplicationController < ActionController::Base
     }
 
     Rails.logger.debug(JSON.generate(log_fields))
+  end
+
+  def instrument_internal_error(exception)
+    ActiveSupport::Notifications.instrument('internal_error.application', exception: exception)
   end
 end

--- a/app/lib/prometheus/metrics.rb
+++ b/app/lib/prometheus/metrics.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Prometheus
+  # A shared global register of Prometheus metrics.
+  #
+  # `Prometheus::Metrics.register_metric`
+  # to create a metric for later use
+  #
+  # `Prometheus::Metrics[name]`
+  # to retrieve a metric by name so that it can be updated
+  class Metrics
+    include Singleton
+
+    attr_reader :registry, :lookup_table
+
+    def initialize
+      @registry = Prometheus::Client.registry
+      @lookup_table = {}
+    end
+
+    def self.register_metric(metric_class, name, docstring, labels = nil)
+      instance.register_metric(metric_class, name, docstring, labels)
+    end
+
+    def self.[](name)
+      instance.lookup_table.fetch(name)
+    end
+
+    def register_metric(metric_class, name, docstring, labels)
+      return if lookup_table.key?(name)
+
+      params = { docstring: docstring }
+      params[:labels] = labels if labels
+
+      counter = metric_class.new(name, params)
+
+      lookup_table[name] = counter
+      registry.register(counter)
+      puts("Created a Prometheus counter of cls #{metric_class} named #{name}")
+    end
+  end
+end

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -2,7 +2,7 @@
 
 module Version
   MAJOR = 1
-  MINOR = 5
+  MINOR = 6
   REVISION = 0
   VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
 end

--- a/app/subscribers/action_dispatch_prometheus_subscriber.rb
+++ b/app/subscribers/action_dispatch_prometheus_subscriber.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Subscribe to :action_dispatch events
+class ActionDispatchPrometheusSubscriber < ActiveSupport::Subscriber
+  attach_to :action_dispatch
+
+  def request(_event)
+    mem = GetProcessMem.new
+
+    Prometheus::Metrics[:memory_used_mb].set(mem.mb)
+  end
+end

--- a/app/subscribers/application_prometheus_subscriber.rb
+++ b/app/subscribers/application_prometheus_subscriber.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Subscribe to :application events
+class ApplicationPrometheusSubscriber < ActiveSupport::Subscriber
+  attach_to :application
+
+  def internal_error(_event)
+    Prometheus::Metrics[:internal_application_error].increment
+  end
+end

--- a/app/subscribers/data_api_prometheus_subscriber.rb
+++ b/app/subscribers/data_api_prometheus_subscriber.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Subscribe to :data_api events
+class DataApiPrometheusSubscriber < ActiveSupport::Subscriber
+  attach_to :data_api
+
+  def response(event)
+    response = event.payload[:response]
+
+    Prometheus::Metrics[:data_api_status].increment(labels: { status: response.status.to_s })
+  end
+
+  def connection_failure(_event)
+    Prometheus::Metrics[:data_api_connection_failure].increment
+  end
+
+  def service_exception(_event)
+    Prometheus::Metrics[:data_api_service_exception].increment
+  end
+end

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
-# This file is used by Rack-based servers to start the application.
+require_relative 'config/environment'
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+
+# use Rack::Deflator
+use Prometheus::Middleware::Collector
+use Prometheus::Middleware::Exporter
 
 require ::File.expand_path('config/environment', __dir__)
 run Rails.application

--- a/config/initializers/load_notification_subscribers.rb
+++ b/config/initializers/load_notification_subscribers.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Dir[Rails.root.join('app', 'subscribers', '**', '*_subscriber.rb')].sort.each do |source|
+  require source
+end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Prometheus counters
 Prometheus::Metrics.register_metric(
   Prometheus::Client::Counter, :data_api_status, 'Response from data API', [:status]
 )
@@ -7,8 +8,13 @@ Prometheus::Metrics.register_metric(
   Prometheus::Client::Counter, :data_api_connection_failure, 'Could not connect to back-end data API'
 )
 Prometheus::Metrics.register_metric(
-  Prometheus::Client::Gauge, :memory_used_mb, 'Process memory usage in mb'
+  Prometheus::Client::Counter, :data_api_service_exception, 'The response from the back-end data API was not processed'
 )
 Prometheus::Metrics.register_metric(
   Prometheus::Client::Counter, :internal_application_error, 'Unexpected events and internal error count'
+)
+
+# Prometheus gauges
+Prometheus::Metrics.register_metric(
+  Prometheus::Client::Gauge, :memory_used_mb, 'Process memory usage in mb'
 )

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Prometheus::Metrics.register_metric(
+  Prometheus::Client::Counter, :data_api_status, 'Response from data API', [:status]
+)
+Prometheus::Metrics.register_metric(
+  Prometheus::Client::Counter, :data_api_connection_failure, 'Could not connect to back-end data API'
+)
+Prometheus::Metrics.register_metric(
+  Prometheus::Client::Gauge, :memory_used_mb, 'Process memory usage in mb'
+)
+Prometheus::Metrics.register_metric(
+  Prometheus::Client::Counter, :internal_application_error, 'Unexpected events and internal error count'
+)

--- a/test/prometheus/dev.yml
+++ b/test/prometheus/dev.yml
@@ -1,0 +1,37 @@
+# my global config
+global:
+  scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+          # - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  # - "first_rules.yml"
+  # - "second_rules.yml"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: "prometheus"
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "ppd"
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: ["localhost:3000"]


### PR DESCRIPTION
This PR addresses epimorphics/hmlr-linked-data#57 by adding support for Prometheus monitoring on the `/metrics` endpoint.

Internally, we set up `ActiveSupport::Notification` events to record events of interest, then listen to those events to add data to the Prometheus metrics. In addition, the standard Rack middleare provided by the Ruby Prometheus client adds a number of basic HTTP metrics automatically.

- Add Prometheus dependencies
- Inject Rack middleware for Prometheus
- Instrument internal errors
- Add the core machinery for Prometheus monitoring
- Add Prometheus setup for local testing
- Update the README
