### PR TITLE
Fix repository reference

### DIFF
--- a/.github/workflows/publish-deploy.yml
+++ b/.github/workflows/publish-deploy.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       # Repostory specific
       ansible_repo:     epimorphics/hmlr-ansible-deployment
-      ansible_repo_ref: master/main
+      ansible_repo_ref: master
       host_prefix:      hmlr
       # Fixed
       deploy: "${{ needs.publish.outputs.deploy }}"


### PR DESCRIPTION
Suspect use of master/main in the readme was to indicate 'pick one'.
For hmlr the default branch is master.