### PR TITLE
Ensure startup messages are in JSON format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ linked data.
 
 - (Ian) Switch to using local gems from GitHub Package Registry
 - (Ian) Update Prometheus metric to follow local best practice
+- (Ian) Ensure Rails and Puma startup messages log as JSON
 
 ## 1.6.0 - 2022-01-31
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,27 @@ require 'rails/test_unit/railtie'
 # you've limited to :test, :development, or :production.
 Bundler.require(:default, Rails.env)
 
+# Monkey-patch the bit of Rails that emits the start-up log message, so that it
+# is written out in JSON format that our combined logging service can handle
+# This versio is Rails 5.x specific. A different pattern is needed for Rails 6
+# applications.
+module Rails
+  # :nodoc:
+  class Server
+    # :nodoc:
+    def print_boot_information
+      url = "on #{options[:SSLEnable] ? 'https' : 'http'}://#{options[:Host]}:#{options[:Port]}"
+
+      msg = {
+        level: 'INFO',
+        ts: DateTime.now.rfc3339(3),
+        message: "Starting #{server} Rails #{Rails.version} in #{Rails.env} #{url}"
+      }
+      puts msg.to_json
+    end
+  end
+end
+
 module PpdExplorer
   # :nodoc:
   class Application < Rails::Application

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,7 +30,8 @@ PpdExplorer::Application.configure do
   config.assets.quiet = true
 
   config.log_tags = %i[subdomain request_id request_method]
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  $stdout.sync = true
+  config.logger = JsonRailsLogger::Logger.new($stdout)
 
   config.api_service_url = ENV['API_SERVICE_URL'] || 'http://localhost:8080'
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Puma can serve each request in a thread from an internal thread pool.
+# The `threads` method setting takes two numbers: a minimum and maximum.
+# Any libraries that use thread pools should be configured to match
+# the maximum value specified for Puma. Default is set to 5 threads for minimum
+# and maximum; this matches the default thread size of Active Record.
+#
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
+min_threads_count = ENV.fetch('RAILS_MIN_THREADS', max_threads_count)
+threads min_threads_count, max_threads_count
+
+# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+#
+port        ENV.fetch('PORT', 3000)
+
+# Specifies the `environment` that Puma will run in.
+#
+environment ENV.fetch('RAILS_ENV', 'development')
+
+# Specifies the `pidfile` that Puma will use.
+pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
+
+# Specifies the number of `workers` to boot in clustered mode.
+# Workers are forked web server processes. If using threads and workers together
+# the concurrency of the application would be max `threads` * `workers`.
+# Workers do not work on JRuby or Windows (both of which do not support
+# processes).
+#
+# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+
+# Use the `preload_app!` method when specifying a `workers` number.
+# This directive tells Puma to first boot the application and load code
+# before forking the application. This takes advantage of Copy On Write
+# process behavior so workers use less memory.
+#
+# preload_app!
+
+# Allow puma to be restarted by `rails restart` command.
+plugin :tmp_restart
+
+# Use a custom log formatter to emit Puma log messages in a JSON format
+log_formatter do |str|
+  {
+    level: 'INFO',
+    ts: DateTime.now.rfc3339(3),
+    message: str
+  }.to_json
+end


### PR DESCRIPTION
epimorphics/hmlr-linked-data#87

Some tweaks to ensure that startup and shutdown messages from Rails and
Puma are emitted in JSON format.
