### PR TITLE
issue/87 further log improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN ./bin/bundle config set --local without 'development test'
 
 RUN ./bin/bundle install \
   && RAILS_ENV=production bundle exec rake assets:precompile \
-  && mkdir -p 777 /usr/src/app/coverage
+  && mkdir -m 777 /usr/src/app/coverage
 
 # Start a new build stage to minimise the final image size
 FROM base

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,7 +332,7 @@ GEM
 GEM
   remote: https://rubygems.pkg.github.com/epimorphics/
   specs:
-    data_services_api (1.3.1)
+    data_services_api (1.3.2)
       faraday_middleware (~> 1.2.0)
       json (~> 2.6.1)
       yajl-ruby (~> 1.4.1)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,11 +13,11 @@ fi
 
 if [ -z "API_SERVICE_URL" ]
 then
-  echo "{'ts': ${date}, 'message': {'text: 'You have not specified an API_SERVICE_URL', 'level': 'ERROR'}}" >&2
+  echo "{'ts': '`date -Iseconds`', 'message': {'text: 'You have not specified an API_SERVICE_URL', 'level': 'ERROR'}}" >&2
   exit 1
 fi
 
-echo API_SERVICE_URL:  ${API_SERVICE_URL}
+echo "{'ts': '`date -Iseconds`', 'message': {'text: 'PPD starting with API_SERVICE_URL ${API_SERVICE_URL}', 'level': 'INFO'}}"
 
 # Handle secrets based on env
 if [ "$RAILS_ENV" == "production" ] && [ -z "$SECRET_KEY_BASE" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,11 +13,11 @@ fi
 
 if [ -z "API_SERVICE_URL" ]
 then
-  echo "{'ts': '`date -Iseconds`', 'message': {'text: 'You have not specified an API_SERVICE_URL', 'level': 'ERROR'}}" >&2
+  echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified an API_SERVICE_URL', 'level': 'ERROR'}}" >&2
   exit 1
 fi
 
-echo "{'ts': '`date -Iseconds`', 'message': {'text: 'PPD starting with API_SERVICE_URL ${API_SERVICE_URL}', 'level': 'INFO'}}"
+echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'PPD starting with API_SERVICE_URL ${API_SERVICE_URL}', 'level': 'INFO'}}"
 
 # Handle secrets based on env
 if [ "$RAILS_ENV" == "production" ] && [ -z "$SECRET_KEY_BASE" ]


### PR DESCRIPTION
This PR addresses further improvements in standardised (JSON-only) logging:

- Entrypoint.sh should only emit JSON
- Pull in upstream changes in API logging

In particular, with the upstream change we now report a single log entry
for API calls, recording the URL, status and duration. For example:

```json
{
  "level": "INFO",
  "ts": "2022-04-04T20:14:58.612Z",
  "rails": {
    "environment": "development",
    "url": "http://localhost:8080/landregistry/id/ppd?_limit=100\u0026search-paon=rose+cottage\u0026searchPath=propertyAddress",
    "message": "GET from API"
  },
  "status": 200,
  "duration": 1.612488262
}
{
  "level": "INFO",
  "ts": "2022-04-04T20:15:03.765Z",
  "rails": {
    "environment": "development",
    "url": "http://localhost:8080/landregistry/id/ppd?_count=%40id\u0026_limit=10000\u0026search-paon=rose+cottage\u0026searchPath=propertyAddress",
    "message": "GET from API"
  },
  "status": 200,
  "duration": 5.1462943
}
```
