### PR TITLE
Update to Sentry-Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'font-awesome-rails'
 gem 'get_process_mem'
 gem 'jquery-ui-rails'
 gem 'prometheus-client', '~> 4.0'
-gem 'sentry-raven'
+gem 'sentry-rails', '~> 5.2'
 gem 'yajl-ruby', require: 'yajl'
 
 source 'https://rubygems.pkg.github.com/epimorphics' do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,8 +288,11 @@ GEM
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
+    sentry-rails (5.2.1)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 5.2.1)
+    sentry-ruby-core (5.2.1)
+      concurrent-ruby
     sexp_processor (4.16.0)
     simplecov (0.21.2)
       docile (~> 1.1)
@@ -396,7 +399,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails
   sdoc
-  sentry-raven
+  sentry-rails (~> 5.2)
   simplecov
   stackprof
   uglifier (>= 1.3.0)

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ Something roughly equivalent should be possible on Windows and Mac as well.
 We use a number of environment variables to determine the runtime behaviour
 of the application:
 
-| name                       | description                                                          | typical value                                    |
-| -------------------------- | -------------------------------------------------------------------- | ------------------------------------------------ |
-| `RAILS_RELATIVE_URL_ROOT`  | The path from the server root to the application                     | `/app/ppd`                                       |
-| `API_SERVICE_URL`          | The base URL from which data is accessed, including the HTTP scheme  | `http://localhost:8080`                          |
+| name                       | description                                                          | typical value              |
+| -------------------------- | -------------------------------------------------------------------- | -------------------------- |
+| `RAILS_RELATIVE_URL_ROOT`  | The path from the server root to the application                     | `/app/ppd`                 |
+| `API_SERVICE_URL`          | The base URL from which data is accessed, including the HTTP scheme  | `http://localhost:8080`    |
+| `SENTRY_API_KEY`           | The DSN for sending reports to the PPD Sentry account                |                            |

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,10 +1,12 @@
 # frozen-string-literal: true
 
-Raven.configure do |config|
-  config.dsn = config.dsn = 'https://06e1842bac0b49fcae94e8a33ef30910@sentry.io/1859747'
-  config.current_environment = ENV['DEPLOYMENT_ENVIRONMENT'] || Rails.env
-  config.environments = %w[production test]
-  config.release = Version::VERSION
-  config.tags = { app: 'lr-dgu-ppd' }
-  config.excluded_exceptions += ['ActionController::BadRequest']
+if ENV['SENTRY_API_KEY']
+  Sentry.init do |config|
+    config.dsn = ENV['SENTRY_API_KEY']
+    config.environment = ENV['DEPLOYMENT_ENVIRONMENT'] || Rails.env
+    config.enabled_environments = %w[production test]
+    config.release = Version::VERSION
+    config.breadcrumbs_logger = %i[active_support_logger http_logger]
+    config.excluded_exceptions += ['ActionController::BadRequest']
+  end
 end


### PR DESCRIPTION
Update to use the latest version of the Sentry library. This slightly
changes the API for configuring Sentry.

Also factor out the DSN so that it is passed-in via an environment
variable.
