### PR TITLE
Collective lift and shift updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ Metrics/ClassLength:
     - test/**/*
 
 Metrics/BlockLength:
+  Max: 30
   Exclude:
     - test/**/*
     - lib/tasks/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ This app allows the user to explore HMLR price-paid open linked data.
   current version `~>1.3.5` (this is to cover out of sync release versions)
 - (Jon) Updated the production `lr_common_styles` gem version to be at least the
   current version `~>1.9.1` (this is to cover out of sync release versions)
-- (Jon) Renamed the global env variable `RAILS_RELATIVE_URL_ROOT` to
-  `APPLICATION_ROOT` to be more clear on it's use in the `entrypoint.sh` code.
 - (Jon) Refactored better guards in `entrypoint.sh` to ensure the required env
   vars are set accordingly or deployment will fail noisily.
 - (Jon) Refactored the error messages displayed to be semantically formatted as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This app allows the user to explore HMLR price-paid open linked data.
 
-## 1.7.1 - 2023-01
+## 1.7.1 - 2023-03-10
 
 - (Jon) Refactors the elapsed time calculated for API requests to be resolved as
   microseconds rather than milliseconds. This is to improve the reporting of the
@@ -10,9 +10,11 @@ This app allows the user to explore HMLR price-paid open linked data.
 - (Jon) Minor text changes to the `Gemfile` to include instructions for running
   Epimorphics specific gems locally during the development of those gems.
 - (Jon) Updated the production `data_services_api` gem version to be at least
-  the current version`~>1.3.2` (this is to cover out of sync release versions)
+  the current version`~>1.3.3` (this is to cover out of sync release versions)
+- (Jon) Updated the production `json_rails_logger` gem version to be at least the
+  current version `~>1.3.5` (this is to cover out of sync release versions)
 - (Jon) Updated the production `lr_common_styles` gem version to be at least the
-  current version `~>1.9.0` (this is to cover out of sync release versions)
+  current version `~>1.9.1` (this is to cover out of sync release versions)
 - (Jon) Renamed the global env variable `RAILS_RELATIVE_URL_ROOT` to
   `APPLICATION_PATH` to be more clear on it's use in the codebase.
 - (Jon) Refactored better guards in `entrypoint.sh` to ensure the required env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This app allows the user to explore HMLR price-paid open linked data.
 
 ## 1.7.1 - 2023-03-10
 
+- (Jon) Added the updated configuration for the AWS credential improvements as
+  per other readme's; included further info to run the application locally;
+  resolved a markdown linting issue with using HTML in markdown.
 - (Jon) Refactors the elapsed time calculated for API requests to be resolved as
   microseconds rather than milliseconds. This is to improve the reporting of the
   elapsed time in the system tooling logs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This app allows the user to explore HMLR price-paid open linked data.
 - (Jon) Updated the production `lr_common_styles` gem version to be at least the
   current version `~>1.9.1` (this is to cover out of sync release versions)
 - (Jon) Renamed the global env variable `RAILS_RELATIVE_URL_ROOT` to
-  `APPLICATION_PATH` to be more clear on it's use in the codebase.
+  `APPLICATION_PATH` to be more clear on it's use in the `entrypoint.sh` code.
 - (Jon) Refactored better guards in `entrypoint.sh` to ensure the required env
   vars are set accordingly or deployment will fail noisily.
 - (Jon) Refactored the error messages displayed to be semantically formatted as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 This app allows the user to explore HMLR price-paid open
 linked data.
 
+## 1.7.1 - 2023-01
+
+- (Jon) Refactors the elapsed time calculated for API requests to be resolved
+  as microseconds rather than milliseconds. This is to improve the reporting of
+  the elapsed time in the system tooling logs.
+- (Jon) Minor text changes to the `Gemfile` to include instructions for running
+  Epimorphics specific gems locally during the development of those gems.
+- (Jon) Updated the production `data_services_api` gem version to be at least
+  the current version`~>1.3.2` (this is to cover out of sync release versions)
+- (Jon) Updated the production `lr_common_styles` gem version to be at least the
+  current version `~>1.9.0` (this is to cover out of sync release versions)
+
 ## 1.7.0 - 2022-04-07
 
 - (Ian) Adopt all of the current Epimorphics best-practice deployment patterns,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ This app allows the user to explore HMLR price-paid open linked data.
   variable instead of being possibly displayed outside of the intended context.
 - (Jon) Refactored the version cadence creation to include a SUFFIX value if
   provided; otherwise no SUFFIX is included in the version number.
+- (Jon) Adjusted the processing of error status to use the application template;
+  also includes adjustments to not double render the error response.
 
 ## 1.7.0 - 2022-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,25 @@
 # HMLR PPD explorer
 
-This app allows the user to explore HMLR price-paid open
-linked data.
+This app allows the user to explore HMLR price-paid open linked data.
 
 ## 1.7.1 - 2023-01
 
-- (Jon) Refactors the elapsed time calculated for API requests to be resolved
-  as microseconds rather than milliseconds. This is to improve the reporting of
-  the elapsed time in the system tooling logs.
+- (Jon) Refactors the elapsed time calculated for API requests to be resolved as
+  microseconds rather than milliseconds. This is to improve the reporting of the
+  elapsed time in the system tooling logs.
 - (Jon) Minor text changes to the `Gemfile` to include instructions for running
   Epimorphics specific gems locally during the development of those gems.
 - (Jon) Updated the production `data_services_api` gem version to be at least
   the current version`~>1.3.2` (this is to cover out of sync release versions)
 - (Jon) Updated the production `lr_common_styles` gem version to be at least the
   current version `~>1.9.0` (this is to cover out of sync release versions)
+- (Jon) Renamed the global env variable `RAILS_RELATIVE_URL_ROOT` to
+  `APPLICATION_PATH` to be more clear on it's use in the codebase.
+- (Jon) Refactored better guards in `entrypoint.sh` to ensure the required env
+  vars are set accordingly or deployment will fail noisily.
+- (Jon) Refactored the error messages displayed to be semantically formatted as
+  well as incorporated ALL lines for the returned message to be held in the
+  variable instead of being possibly displayed outside of the intended context.
 
 ## 1.7.0 - 2022-04-07
 
@@ -61,8 +67,7 @@ linked data.
 
 ## 1.4.0 - 2020-09-22 (Ian)
 
-- switched from JQuery datePicker component to use browser date
-  input controls
+- switched from JQuery datePicker component to use browser date input controls
 
 ## 1.3.1 - 2020-09-22 (Ian)
 
@@ -70,8 +75,8 @@ linked data.
 
 ## 1.3.0 - 2020-09-20 (Ian)
 
-- A collection of WCAG fixes under GH-117. Pending manual testing,
-  this should bring the app into WCAG compliance
+- A collection of WCAG fixes under GH-117. Pending manual testing, this should
+  bring the app into WCAG compliance
 
 ## 1.2.2 - 2020-07-06
 
@@ -79,30 +84,28 @@ linked data.
 
 ## 1.2.1 - 2020-03-19
 
-- Update some dependent gems to resolve CVE warnings, but keep
-  Rails at version 5.
+- Update some dependent gems to resolve CVE warnings, but keep Rails at version
+  5.
 
 ## 1.2.0 - 2019-12-17
 
-- Changed minor version number as we've switched to using a
-  separate Sentry project for this app.
+- Changed minor version number as we've switched to using a separate Sentry
+  project for this app.
 
 ## 1.1.3 - 2019-12-09
 
-- Add `ActionController::BadRequest` to the list of ignored
-  exceptions for Sentry
-- Fix method name clash with `ApplicationController.render_error`
-  and `SearchController.render_error` leading to Sentry warning
+- Add `ActionController::BadRequest` to the list of ignored exceptions for
+  Sentry
+- Fix method name clash with `ApplicationController.render_error` and
+  `SearchController.render_error` leading to Sentry warning
 
 ## 2019-11-15
 
 - Updated README
-- skipped some tests that are blocking due to chromedriver
-  (see GH-101)
+- skipped some tests that are blocking due to chromedriver (see GH-101)
 - fix rubocop warnings
-- update the log files to write more structured information
-  that will help with diagnosing intrusively slow queries
-  (GH-97)
+- update the log files to write more structured information that will help with
+  diagnosing intrusively slow queries (GH-97)
 
 ## 2019-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This app allows the user to explore HMLR price-paid open linked data.
 - (Jon) Updated the production `lr_common_styles` gem version to be at least the
   current version `~>1.9.1` (this is to cover out of sync release versions)
 - (Jon) Renamed the global env variable `RAILS_RELATIVE_URL_ROOT` to
-  `APPLICATION_PATH` to be more clear on it's use in the `entrypoint.sh` code.
+  `APPLICATION_ROOT` to be more clear on it's use in the `entrypoint.sh` code.
 - (Jon) Refactored better guards in `entrypoint.sh` to ensure the required env
   vars are set accordingly or deployment will fail noisily.
 - (Jon) Refactored the error messages displayed to be semantically formatted as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This app allows the user to explore HMLR price-paid open linked data.
 - (Jon) Refactored the error messages displayed to be semantically formatted as
   well as incorporated ALL lines for the returned message to be held in the
   variable instead of being possibly displayed outside of the intended context.
+- (Jon) Refactored the version cadence creation to include a SUFFIX value if
+  provided; otherwise no SUFFIX is included in the version number.
 
 ## 1.7.0 - 2022-04-07
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,29 +19,40 @@ RUN apk add --update build-base
 
 WORKDIR /usr/src/app
 
-COPY config.ru Dockerfile entrypoint.sh Gemfile Gemfile.lock Rakefile ./
-COPY app app
+COPY config.ru entrypoint.sh Gemfile Gemfile.lock Rakefile ./
 COPY bin bin
+
+COPY .bundle/config /root/.bundle/config
+
+RUN ./bin/bundle install && mkdir log
+
+COPY app app
 COPY config config
 COPY lib lib
 COPY public public
 COPY vendor vendor
-RUN mkdir log
 
 # Copy the bundle config
 # **Important** the destination for this copy **must not** be in WORKDIR,
 # or there is a risk that the GitHub PAT could be part of the final image
 # in a potentially leaky way
-COPY .bundle/config /root/.bundle/config
-
-RUN ./bin/bundle config set --local without 'development test'
-
-RUN ./bin/bundle install \
-  && RAILS_ENV=production bundle exec rake assets:precompile \
+RUN RAILS_ENV=production bundle exec rake assets:precompile \
   && mkdir -m 777 /usr/src/app/coverage
 
 # Start a new build stage to minimise the final image size
 FROM base
+
+ARG image_name
+ARG git_branch
+ARG git_commit_hash
+ARG github_run_number
+ARG VERSION
+
+LABEL com.epimorphics.name=$image_name \
+      com.epimorphics.branch=$git_branch \
+      com.epimorphics.build=$github_run_number \
+      com.epimorphics.commit=$git_commit_hash \
+      com.epimorphics.version=$VERSION
 
 RUN addgroup -S app && adduser -S -G app app
 EXPOSE 3000

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,22 @@ end
 
 gem 'byebug', group: %i[development test]
 
+group :test do
+  gem 'capybara'
+  gem 'capybara_minitest_spec'
+  gem 'capybara-selenium'
+  gem 'json_expressions'
+  gem 'minitest-rails'
+  gem 'minitest-reporters'
+  gem 'minitest-spec-rails'
+  gem 'minitest-vcr'
+  gem 'mocha'
+  gem 'simplecov', require: false
+  gem 'vcr'
+  gem 'webdrivers'
+  gem 'webmock'
+end
+
 group :development do
   gem 'rb-readline'
 
@@ -53,24 +69,14 @@ gem 'prometheus-client', '~> 4.0'
 gem 'sentry-rails', '~> 5.2'
 gem 'yajl-ruby', require: 'yajl'
 
-source 'https://rubygems.pkg.github.com/epimorphics' do
-  gem 'data_services_api'
-  gem 'json_rails_logger'
-  gem 'lr_common_styles'
-end
+# TODO: For running the app locally for testing you can set this to your local path
+# gem 'data_services_api', '~> 1.3.2', path: '~/Epimorphics/shared/data_services_api/'
+# gem 'json_rails_logger', '~> 0.3.4', path: '~/Epimorphics/shared/json-rails-logger/'
+# gem 'lr_common_styles', '~> 1.9.0', path: '~/Epimorphics/clients/land-registry/projects/lr-common-styles/'
 
-group :test do
-  gem 'capybara'
-  gem 'capybara_minitest_spec'
-  gem 'capybara-selenium'
-  gem 'json_expressions'
-  gem 'minitest-rails'
-  gem 'minitest-reporters'
-  gem 'minitest-spec-rails'
-  gem 'minitest-vcr'
-  gem 'mocha'
-  gem 'simplecov', require: false
-  gem 'vcr'
-  gem 'webdrivers'
-  gem 'webmock'
+# TODO: In production you want to set this to the gem from the epimorphics package repo
+source 'https://rubygems.pkg.github.com/epimorphics' do
+  gem 'data_services_api', '~> 1.3.2'
+  gem 'json_rails_logger', '~> 0.3.4'
+  gem 'lr_common_styles', '~> 1.9.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'uglifier', '>= 1.3.0'
 
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
-gem 'libv8-node',  '>= 16.10.0.0'
+gem 'libv8-node', '>= 16.10.0.0'
 
 gem 'jbuilder'
 gem 'jquery-rails'
@@ -69,14 +69,16 @@ gem 'prometheus-client', '~> 4.0'
 gem 'sentry-rails', '~> 5.2'
 gem 'yajl-ruby', require: 'yajl'
 
+# rubocop:disable Layout/LineLength
 # TODO: For running the app locally for testing you can set this to your local path
-# gem 'data_services_api', '~> 1.3.2', path: '~/Epimorphics/shared/data_services_api/'
-# gem 'json_rails_logger', '~> 0.3.4', path: '~/Epimorphics/shared/json-rails-logger/'
-# gem 'lr_common_styles', '~> 1.9.0', path: '~/Epimorphics/clients/land-registry/projects/lr-common-styles/'
+# gem 'data_services_api', '~> 1.3.3', path: '~/Epimorphics/shared/data_services_api/'
+# gem 'json_rails_logger', '~> 0.3.5', path: '~/Epimorphics/shared/json-rails-logger/'
+# gem 'lr_common_styles', '~> 1.9.1', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles/'
+# rubocop:enable Layout/LineLength
 
 # TODO: In production you want to set this to the gem from the epimorphics package repo
 source 'https://rubygems.pkg.github.com/epimorphics' do
-  gem 'data_services_api', '~> 1.3.2'
-  gem 'json_rails_logger', '~> 0.3.4'
-  gem 'lr_common_styles', '~> 1.9.0'
+  gem 'data_services_api', '~> 1.3.3'
+  gem 'json_rails_logger', '~> 0.3.5'
+  gem 'lr_common_styles', '~> 1.9.1'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,8 @@ gem 'sentry-rails', '~> 5.2'
 gem 'yajl-ruby', require: 'yajl'
 
 # rubocop:disable Layout/LineLength
-# TODO: For running the app locally for testing you can set this to your local path
+# TODO: While running the rails app locally for testing you can set gems to your local path
+# ! These "local" paths do not work with a docker image - use the repo instead
 # gem 'data_services_api', '~> 1.3.3', path: '~/Epimorphics/shared/data_services_api/'
 # gem 'json_rails_logger', '~> 0.3.5', path: '~/Epimorphics/shared/json-rails-logger/'
 # gem 'lr_common_styles', '~> 1.9.1', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles/'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
-    json (2.6.1)
+    json (2.6.3)
     json_expressions (0.9.0)
     libv8-node (16.10.0.0)
     libv8-node (16.10.0.0-aarch64-linux)
@@ -336,15 +336,15 @@ GEM
 GEM
   remote: https://rubygems.pkg.github.com/epimorphics/
   specs:
-    data_services_api (1.3.2)
+    data_services_api (1.3.3)
       faraday_middleware (~> 1.2.0)
       json (~> 2.6.1)
       yajl-ruby (~> 1.4.1)
-    json_rails_logger (0.3.4)
+    json_rails_logger (0.3.5.3)
       json
       lograge
       railties
-    lr_common_styles (1.9.0)
+    lr_common_styles (1.9.1.1)
       bootstrap-sass (~> 3.4.0)
       font-awesome-rails (~> 4.7.0.1)
       govuk_elements_rails (~> 2.0.0)
@@ -362,6 +362,7 @@ PLATFORMS
   -darwin-20
   aarch64-linux
   x86_64-darwin-17
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -370,7 +371,7 @@ DEPENDENCIES
   capybara
   capybara-selenium
   capybara_minitest_spec
-  data_services_api!
+  data_services_api (~> 1.3.3)!
   execjs (< 2.8.0)
   faraday
   faraday_middleware
@@ -382,9 +383,9 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   json_expressions
-  json_rails_logger!
+  json_rails_logger (~> 0.3.5)!
   libv8-node (>= 16.10.0.0)
-  lr_common_styles!
+  lr_common_styles (~> 1.9.1)!
   memory_profiler
   minitest-rails
   minitest-reporters
@@ -409,4 +410,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.3.5
+   2.4.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,11 +340,11 @@ GEM
       faraday_middleware (~> 1.2.0)
       json (~> 2.6.1)
       yajl-ruby (~> 1.4.1)
-    json_rails_logger (0.3.5.3)
+    json_rails_logger (0.3.5.4)
       json
       lograge
       railties
-    lr_common_styles (1.9.1.1)
+    lr_common_styles (1.9.1.2)
       bootstrap-sass (~> 3.4.0)
       font-awesome-rails (~> 4.7.0.1)
       govuk_elements_rails (~> 2.0.0)
@@ -410,4 +410,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.4.4
+   2.4.8

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ BUNDLER_VERSION?=$(shell tail -1 Gemfile.lock | tr -d ' ')
 ECR?=${ACCOUNT}.dkr.ecr.eu-west-1.amazonaws.com
 GPR_OWNER?=epimorphics
 NAME?=$(shell awk -F: '$$1=="name" {print $$2}' deployment.yaml | sed -e 's/[[:blank:]]//g')
+SHORTNAME?=$(shell echo ${NAME} | cut -f2 -d/)
 PAT?=$(shell read -p 'Github access token:' TOKEN; echo $$TOKEN)
 RUBY_VERSION?=$(shell cat .ruby-version)
 STAGE?=dev
@@ -15,7 +16,7 @@ API_SERVICE_URL?= http://localhost:8080
 BRANCH:=$(shell git rev-parse --abbrev-ref HEAD)
 COMMIT=$(shell git rev-parse --short HEAD)
 VERSION?=$(shell /usr/bin/env ruby -e 'require "./app/lib/version" ; puts Version::VERSION')
-TAG?=$(shell printf '%s-%s-%08d' ${VERSION} ${COMMIT} ${GITHUB_RUN_NUMBER})
+TAG?=$(shell printf '%s_%s_%08d' ${VERSION} ${COMMIT} ${GITHUB_RUN_NUMBER})
 
 ${TAG}:
 	@echo ${TAG}
@@ -24,7 +25,7 @@ IMAGE?=${NAME}/${STAGE}
 REPO?=${ECR}/${IMAGE}
 
 GITHUB_TOKEN=.github-token
-BUNDLE_CFG=.bundle/config
+BUNDLE_CFG=${HOME}/.bundle/config
 
 all: image
 
@@ -39,23 +40,23 @@ assets:
 	@./bin/bundle install
 	@./bin/rails assets:clean assets:precompile
 
-auth: ${BUNDLE_CFG}
+auth: ${GITHUB_TOKEN} ${BUNDLE_CFG}
 
 clean:
 	@[ -d public/assets ] && ./bin/rails assets:clobber || :
 
-image: auth lint test
+image: auth
 	@echo Building ${REPO}:${TAG} ...
-	docker build \
+	@docker build \
 		--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
 		--build-arg RUBY_VERSION=${RUBY_VERSION} \
 		--build-arg BUNDLER_VERSION=${BUNDLER_VERSION} \
-    --build-arg VERSION=${VERSION} \
-    --build-arg git_branch=${BRANCH} \
-    --build-arg git_commit_hash=${COMMIT} \
+		--build-arg VERSION=${VERSION} \
+		--build-arg git_branch=${BRANCH} \
+		--build-arg git_commit_hash=${COMMIT} \
 		--build-arg github_run_number=${GITHUB_RUN_NUMBER} \
-    --build-arg image_name=${NAME} \
-	  --tag ${REPO}:${TAG} \
+		--build-arg image_name=${NAME} \
+		--tag ${REPO}:${TAG} \
 		.
 	@echo Done.
 
@@ -71,10 +72,10 @@ realclean: clean
 	@rm -f ${GITHUB_TOKEN} ${BUNDLE_CFG}
 
 run:
-	@echo "Stopping ppd_explorer ..."
-	@-docker stop ppd_explorer && sleep 10
-	@echo "Starting ppd_explorer ..."
-	@docker run -dp 3000:3000 --rm --name ppd_explorer ${REPO}:${TAG}
+	@echo "Stopping ${SHORTNAME} ..."
+	@-docker stop ${SHORTNAME} && sleep 10
+	@echo "Starting ${SHORTNAME} ..."
+	@docker run -e API_SERVICE_URL=${API_SERVICE_URL} --add-host host.docker.internal:host-gateway -p 3000:3000 --rm --name ${SHORTNAME} ${REPO}:${TAG}
 
 tag:
 	@echo ${TAG}
@@ -91,6 +92,7 @@ vars:
 	@echo "ECR = ${ECR}"
 	@echo "GPR_OWNER = ${GPR_OWNER}"
 	@echo "NAME = ${NAME}"
+	@echo "SHORTNAME = ${SHORTNAME}"
 	@echo "RUBY_VERSION = ${RUBY_VERSION}"
 	@echo "STAGE = ${STAGE}"
 	@echo "COMMIT = ${COMMIT}"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ API_SERVICE_URL?=http://data-api:8080
 BRANCH:=$(shell git rev-parse --abbrev-ref HEAD)
 COMMIT=$(shell git rev-parse --short HEAD)
 VERSION?=$(shell /usr/bin/env ruby -e 'require "./app/lib/version" ; puts Version::VERSION')
-TAG?=$(shell printf '%s_%s_%08d' ${VERSION} ${COMMIT} ${GITHUB_RUN_NUMBER})
+TAG?=$(shell printf '%s-%s-%08d' ${VERSION} ${COMMIT} ${GITHUB_RUN_NUMBER})
 
 ${TAG}:
 	@echo ${TAG}

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,14 @@ ALPINE_VERSION?=3.12
 AWS_REGION?=eu-west-1
 BUNDLER_VERSION?=$(shell tail -1 Gemfile.lock | tr -d ' ')
 ECR?=${ACCOUNT}.dkr.ecr.eu-west-1.amazonaws.com
-GRP_OWNER?=epimorphics
+GPR_OWNER?=epimorphics
 NAME?=$(shell awk -F: '$$1=="name" {print $$2}' deployment.yaml | sed -e 's/[[:blank:]]//g')
 PAT?=$(shell read -p 'Github access token:' TOKEN; echo $$TOKEN)
 RUBY_VERSION?=$(shell cat .ruby-version)
 STAGE?=dev
 API_SERVICE_URL?= http://localhost:8080
 
+BRANCH:=$(shell git rev-parse --abbrev-ref HEAD)
 COMMIT=$(shell git rev-parse --short HEAD)
 VERSION?=$(shell /usr/bin/env ruby -e 'require "./app/lib/version" ; puts Version::VERSION')
 TAG?=$(shell printf '%s-%s-%08d' ${VERSION} ${COMMIT} ${GITHUB_RUN_NUMBER})
@@ -23,12 +24,12 @@ IMAGE?=${NAME}/${STAGE}
 REPO?=${ECR}/${IMAGE}
 
 GITHUB_TOKEN=.github-token
-BUNDLE_CFG=${HOME}/.bundle/config
+BUNDLE_CFG=.bundle/config
 
 all: image
 
 ${BUNDLE_CFG}: ${GITHUB_TOKEN}
-	@./bin/bundle config set --local rubygems.pkg.github.com ${GRP_OWNER}:`cat ${GITHUB_TOKEN}`
+	@./bin/bundle config set --local rubygems.pkg.github.com ${GPR_OWNER}:`cat ${GITHUB_TOKEN}`
 
 ${GITHUB_TOKEN}:
 	@echo ${PAT} > ${GITHUB_TOKEN}
@@ -38,17 +39,22 @@ assets:
 	@./bin/bundle install
 	@./bin/rails assets:clean assets:precompile
 
-auth: ${GITHUB_TOKEN} ${BUNDLE_CFG}
+auth: ${BUNDLE_CFG}
 
 clean:
 	@[ -d public/assets ] && ./bin/rails assets:clobber || :
 
 image: auth lint test
 	@echo Building ${REPO}:${TAG} ...
-	@docker build \
+	docker build \
 		--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
 		--build-arg RUBY_VERSION=${RUBY_VERSION} \
 		--build-arg BUNDLER_VERSION=${BUNDLER_VERSION} \
+    --build-arg VERSION=${VERSION} \
+    --build-arg git_branch=${BRANCH} \
+    --build-arg git_commit_hash=${COMMIT} \
+		--build-arg github_run_number=${GITHUB_RUN_NUMBER} \
+    --build-arg image_name=${NAME} \
 	  --tag ${REPO}:${TAG} \
 		.
 	@echo Done.
@@ -65,9 +71,10 @@ realclean: clean
 	@rm -f ${GITHUB_TOKEN} ${BUNDLE_CFG}
 
 run:
-	@-docker stop ppd_explorer
-	@-docker rm ppd_explorer && sleep 20
-	@docker run -p 3000:3000 --rm --name ppd_explorer ${REPO}:${TAG}
+	@echo "Stopping ppd_explorer ..."
+	@-docker stop ppd_explorer && sleep 10
+	@echo "Starting ppd_explorer ..."
+	@docker run -dp 3000:3000 --rm --name ppd_explorer ${REPO}:${TAG}
 
 tag:
 	@echo ${TAG}
@@ -82,7 +89,7 @@ vars:
 	@echo "AWS_REGION = ${AWS_REGION}"
 	@echo "BUNDLER_VERSION = ${BUNDLER_VERSION}"
 	@echo "ECR = ${ECR}"
-	@echo "GRP_OWNER = ${GRP_OWNER}"
+	@echo "GPR_OWNER = ${GPR_OWNER}"
 	@echo "NAME = ${NAME}"
 	@echo "RUBY_VERSION = ${RUBY_VERSION}"
 	@echo "STAGE = ${STAGE}"

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ ${GITHUB_TOKEN}:
 	@echo ${PAT} > ${GITHUB_TOKEN}
 
 assets:
-	@./bin/bundle config set --local without 'development'
+	@./bin/bundle config set --local without 'development test'
 	@./bin/bundle install
 	@./bin/rails assets:clean assets:precompile
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ IMAGE?=${NAME}/${STAGE}
 REPO?=${ECR}/${IMAGE}
 
 GITHUB_TOKEN=.github-token
-BUNDLE_CFG=${HOME}/.bundle/config
+BUNDLE_CFG=.bundle/config
 
 all: image
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ writing, the following deployment patterns are defined:
 This script is used as the main entry point for starting the app from the `Dockerfile`.
 
 The Rails Framework requires certain values to be set as a Global environment variable
-when starting. To ensure the `RAILS_RELATIVE_URL_ROOT` is only set in one place per
+when starting. To ensure the `APPLICATION_PATH` is only set in one place per
 application we have added this to the `entrypoint.sh` file along with the `SCRIPT_NAME`.
 The Rails secret is also created here.
 
@@ -178,6 +178,6 @@ of the application:
 
 | name                       | description                                                          | typical value              |
 | -------------------------- | -------------------------------------------------------------------- | -------------------------- |
-| `RAILS_RELATIVE_URL_ROOT`  | The path from the server root to the application                     | `/app/ppd`                 |
+| `APPLICATION_PATH`         | The path from the server root to the application                     | `/app/ppd`                 |
 | `API_SERVICE_URL`          | The base URL from which data is accessed, including the HTTP scheme  | `http://localhost:8080`    |
 | `SENTRY_API_KEY`           | The DSN for sending reports to the PPD Sentry account                |                            |

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ writing, the following deployment patterns are defined:
 This script is used as the main entry point for starting the app from the `Dockerfile`.
 
 The Rails Framework requires certain values to be set as a Global environment variable
-when starting. To ensure the `APPLICATION_PATH` is only set in one place per
+when starting. To ensure the `APPLICATION_ROOT` is only set in one place per
 application we have added this to the `entrypoint.sh` file along with the `SCRIPT_NAME`.
 The Rails secret is also created here.
 
@@ -234,7 +234,7 @@ of the application:
 
 | name                       | description                                                          | typical value              |
 | -------------------------- | -------------------------------------------------------------------- | -------------------------- |
-| `APPLICATION_PATH`         | The path from the server root to the application                     | `/app/ppd`                 |
+| `APPLICATION_ROOT`         | The path from the server root to the application                     | `/app/ppd`                 |
 | `API_SERVICE_URL`          | The base URL from which data is accessed, including the HTTP scheme  | `http://localhost:8080`    |
 | `SENTRY_API_KEY`           | The DSN for sending reports to the PPD Sentry account                |                            |
 

--- a/README.md
+++ b/README.md
@@ -1,32 +1,144 @@
 # Price Paid Data (PPD) Explorer
 
-This is the repo for the HM Land Registry
-[PPD explorer](http://landregistry.data.gov.uk/app/ppd),
-which allows users to explore the Price Paid linked-data
-for England and Wales.
+This is the repo for the HM Land Registry [PPD
+explorer](http://landregistry.data.gov.uk/app/ppd), which allows users to
+explore the Price Paid linked-data for England and Wales.
 
 ## Running this service
 
-This application can be run stand-alone as a rails server in `development` mode. 
+This application can be run stand-alone as a rails server in `development` mode.
 However, when deployed, applications will run behind a reverse proxy.
 
-This enables request to be routed to the appropriate application base on the request path.
-In order to simplifiy the proxy configuration we retain the original path where possible.
+This enables requests to be routed to the appropriate application base on the
+request path. In order to simplifiy the proxy configuration we retain the
+original path where possible.
 
-For information on how to running a proxy to mimic production and run multple services
-together see [simple-web-proxy](https://github.com/epimorphics/simple-web-proxy/edit/main/README.md)
+For information on how to running a proxy to mimic production and run multple
+services together read through the information in our
+[simple-web-proxy](https://github.com/epimorphics/simple-web-proxy/edit/main/README.md)
+repository.
 
 If running more than one application locally ensure that each is listerning on a
-separate port and separate path. In the case of running local docker images, the required
-configuration is captured in the `Makefile` and an image can be run by using
+separate port and separate path. In the case of running local docker images, the
+required configuration is captured in the `Makefile` and an image can be run by
+using
+
+```sh
+make image run
+```
+
+or if the image is already built, simply
+
+```sh
+make run
+```
 
 ### Development and Production mode
 
-Applications running in `development` mode default to not use a sub-directory to aid 
-stand-alone development.
+Applications running in `development` mode default to *not* use a sub-directory
+to aid with stand-alone development.
 
-- AWS IAM credentials to connect to the HMLR AWS account (see Dave or Andy)
-- the ECR credentials helper installed locally (see [here](https://github.com/awslabs/amazon-ecr-credential-helper))
+Applications running in `production` mode *do* use a sub-directory i.e.
+`/app/ppd`.
+
+In each case this has been achieved by setting `config.relative_url_root`
+property to this sub-directory within the file
+`config/environments/(development|production).rb`.
+
+If need be, `config.relative_url_root` may by overridden by means of the
+`RAILS_RELATIVE_URL_ROOT` environment variable, althought this could also
+require rebuilding the assets or docker image.
+
+### Running Rails as a server
+
+For developing rails applications you can start the server locally using the
+following command:
+
+```sh
+rails server
+```
+
+and visit <localhost:3000> in your browser.
+
+To change to using `production` mode use the `-e` option; or to change to a
+different port use the `-p` option.
+
+Note: In `production` mode, `SECRET_KEY_BASE` is also required. It is
+insufficient to just set this as the value must be exported. e.g.
+
+```sh
+export SECRET_KEY_BASE=$(./bin/rails secret)
+```
+
+#### Running Rails as a server with a sub-directory via Makefile
+
+```sh
+API_SERVICE_URL=<data-api url> RAILS_ENV=<mode> RAILS_RELATIVE_URL_ROOT=/<path> make server
+```
+
+The default for `RAILS_ENV` here is `development`.
+
+### Building and Running as a docker container
+
+It can be useful to run the compiled Docker image, that will mirror the
+production installation, locally yourself. Assuming you have the [Data API
+running](#running-the-data-api-locally), then you can run the Docker
+image for the app itself as follows:
+
+```sh
+make image run
+```
+
+or, if the image is already built, simply
+
+```sh
+make run
+```
+
+Docker images run in `production` mode.
+
+To test the running application visit `localhost:<port>/<application path>`.
+
+## Runtime Configuration environment variables
+
+We use a number of environment variables to determine the runtime behaviour of
+the application:
+
+| name                       | description                                                             | default value              |
+| -------------------------- | ----------------------------------------------------------------------- | -------------------------- |
+| `API_SERVICE_URL`          | The base URL from which data is accessed, including the HTTP scheme eg. | None                       |
+|                            | <http://localhost:8888> if running a `data-api service` locally         |                            |
+|                            | <http://data-api:8080>  if running a `data-api docker` image locally    |                            |
+| `SECRET_KEY_BASE`          | See [description](https://api.rubyonrails.org/classes/Rails/Application.html#method-i-secret_key_base). | |
+|                            | For `development` mode a acceptable value is already configured, in production mode this should be set to the output of `rails secret`. | |
+|                            | This is handled automatically when starting a docker container, or the `server` `make` target | |
+| `SENTRY_API_KEY`           | The DSN for sending reports to the PPD Sentry account                   | None                       |
+
+### Running the Data API locally
+
+The application connects to the triple store via a `data-api` service.
+
+The easiest way to do this is as a local docker container. The image can be
+built from [lr-data-api repository](https://github.com/epimorphics/lr-data-api).
+or pulled from Amazon Elastic Container Registry
+[ECR](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/018852084843/epimorphics/lr-data-api/dev?region=eu-west-1)
+
+#### Building and running from [lr-data-api repository](https://github.com/epimorphics/lr-data-api)
+
+To build and a run a new docker image check out the [lr-data-api
+repository](https://github.com/epimorphics/lr-data-api) and run
+
+```sh
+make image run
+```
+
+#### Running an existing [ECR](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/018852084843/epimorphics/lr-data-api/dev?region=eu-west-1) image
+
+Obtaining an ECR image requires:
+
+- AWS IAM credentials to connect to the HMLR AWS account
+- the ECR credentials helper installed locally (see
+  [here](https://github.com/awslabs/amazon-ecr-credential-helper))
 - Set the contents of your `~/.docker/config.json` file to be:
 
 ```sh
@@ -51,135 +163,62 @@ To use a credential helper for a specific ECR registry[^1], create a
 }
 ```
 
-With this set up, you should be able to run the container, mapped to
-`localhost:8080` using:
+Once you have a local copy of the required image, it is advisable to run a local
+docker bridge network to mirror production and development environments.
 
-If need be, `config.relative_url_root` may by overridden by means of the
-`RAILS_RELATIVE_URL_ROOT` environment variable, althought this could also
-require rebuilding the assets or docker image.
-
-### Building and Running the docker container
+Running a client application as a docker image from their respective `Makefile`s
+will set this up automatically, but to confirm run
 
 ```sh
-make image run
+docker network inspect dnet
 ```
 
-or, if the image is already built, simply
+To create the docker network run
 
 ```sh
-make run
+docker network create dnet
 ```
-Docker images run in `production` mode.
 
-### Running Rails as a server
-
-For rails applications you can start the server locally using the following command:
+#### To run the Data API as a docker container
 
 ```sh
-rails server -e production -p <port>
+docker run --network dnet -p 8888:8080 --rm --name data-api \
+    -e SERVER_DATASOURCE_ENDPOINT=https://landregistry.data.gov.uk/landregistry/query \
+    018852084843.dkr.ecr.eu-west-1.amazonaws.com/epimorphics/lr-data-api/dev:1.0-SNAPSHOT_a5590d2
 ```
 
-#### Running Rails as a server with a sub-directory
+Which then should produce something like:
 
-```sh
-API_SERVICE_URL=<data-api url> RAILS_ENV=<mode> RAILS_RELATIVE_URL_ROOT=/<path> make server
-```
-The default for `RAILS_ENV` here is `development`.
+```text
+  .   ____          _            __ _ _
+ /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
+( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
+ \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
+  '  |____| .__|_| |_|_| |_\__, | / / / /
+ =========|_|==============|___/=/_/_/_/
+ :: Spring Boot ::        (v2.2.0.RELEASE)
 
-### Running the app locally in dev mode
-
-Assuming the API is running on port 8080 (the default), to start the app locally:
-
-```sh
-API_SERVICE_URL=http://localhost:8080 rails server
-```
-
-And then visit [`localhost:3000`](http://localhost:3000/).
-
-### Running the app locally as a Docker image
-
-It can be useful to run the compiled Docker image, that will be run by the
-production installation, locally yourself. Assuming you have the dev API
-running on `localhost:8080` (the default), then you can run the Docker image
-for the app itself as follows:
-
-```sh
-API_SERVICE_URL=http://host.docker.internal:8080 make run
+{"ts":"2022-03-21T16:12:26.585Z","version":"1","logger_name":"com.epimorphics.SapiNtApplicationKt",
+"thread_name":"main","level":"INFO","level_value":20000,
+"message":"No active profile set, falling back to default profiles: default"}
 ```
 
-Note that `host.docker.internal` is a special alias for `localhost`, which is
-[supported by
-Docker](https://medium.com/@TimvanBaarsen/how-to-connect-to-the-docker-host-from-inside-a-docker-container-112b4c71bc66).
+The latest images can be found here for
+[dev](https://github.com/epimorphics/hmlr-ansible-deployment/blob/master/ansible/group_vars/dev/tags.yml)
+and
+[production](https://github.com/epimorphics/hmlr-ansible-deployment/blob/master/ansible/group_vars/prod/tags.yml).
 
-Assuming the Docker container starts up OK, you will need a proxy to simulate
-the effect of accessing the application via its ingress path
-(`/app/ppd`). There is a [simple web
-proxy](https://github.com/epimorphics/simple-web-proxy) that you can use.
+The identity of the Docker image will change periodically so the full list of
+versions can be found at [AWS
+ECR](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/018852084843/epimorphics/lr-data-api/dev?region=eu-west-1)
 
-With the simple web proxy, and the two Docker containers running, access the
-application as
-[`localhost:3001/app/ukhpi/`](http://localhost:3001/app/ukhpi/).
+N.B. Port 8080 should be avoided to allow for a reverse proxy to run on this
+port.
 
-### Coding standards
-
-
-To test the running application visit `localhost:<port>/{application path}`.
-
-## Runtime Configuration environment variables
-
-We use a number of environment variables to determine the runtime behaviour
-of the application:
-
-| name                       | description                                                             | default value              |
-| -------------------------- | ----------------------------------------------------------------------- | -------------------------- |
-| `API_SERVICE_URL`          | The base URL from which data is accessed, including the HTTP scheme eg. | None                       |
-|                            | http://localhost:8888 if running a `data-api` service locally           |                            |
-|                            | http://data-api:8080  if running a `data-api` docker image locally      |                            |
-| `SECRET_KEY_BASE`          | See [description](https://api.rubyonrails.org/classes/Rails/Application.html#method-i-secret_key_base).
-For `development` mode a acceptable value is already configured, in production mode this should be set to the output of `rails secret`.
-This is handled automatically when starting a docker container, or the `server` `make` target | |
-| `SENTRY_API_KEY`           | The DSN for sending reports to the PPD Sentry account                   | None                       |
-
-
-### Running the Data API during locally
-
-The application connects to the triple store via a `data-api` service.
-
-The easiest way to do this is as a local docker container. The image can be built from [lr-data-api repository](https://github.com/epimorphics/lr-data-api).
-or pulled from Amazon Elastic Container Registry [ECR](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/018852084843/epimorphics/lr-data-api/dev?region=eu-west-1)
-
-#### Building and running from [lr-data-api repository](https://github.com/epimorphics/lr-data-api)
-
-To build and a run a new docker image check out the [lr-data-api repository](https://github.com/epimorphics/lr-data-api) and run
-```sh
-make image run
-```
-
-#### Running an existing image from
-
-See [here](https://github.com/epimorphics/lr-data-api#Running-an-existing-image) on how to run an
-existing image from [ECR](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/018852084843/epimorphics/lr-data-api/dev?region=eu-west-1)
-
-
-- git tag matching `vNNN`, e.g. `v1.2.3` \
-  Automatically deployed to the production environment
-- git branch `dev-infrastructure` \
-  Automatically deployed to the dev environment.
+With this set up, the api service is available on `http://localhost:8888` from
+the host or `http://data-api:8080` from inside other docker containers.
 
 ## Developer notes
-
-### Code overview
-
-The Rails Framework requires certain values to be set as a Global environment variable
-when starting. To ensure the `APPLICATION_ROOT` is only set in one place per
-application we have added this to the `entrypoint.sh` file along with the `SCRIPT_NAME`.
-The Rails secret is also created here.
-
-The app does not interact directly with the triple store.
-Instead, we use a simple DSL to send queries to the
-[DS API](http://github.com/epimorphics/data-API). DS API uses
-the structure of the hypercube, represented as a _data structure
-definition_ (DSD), to convert the DSL queries to SPARQL.
 
 ### Coding standards
 
@@ -196,51 +235,48 @@ rails test
 [Prometheus](https://prometheus.io) is set up to provide metrics on the
 `/metrics` endpoint. The following metrics are recorded:
 
-- `api_status` (counter)
-  Response from data API, labelled by response status code
-- `api_requests` (counter)
-  Count of requests to the data API, labelled by result success/failure
-- `api_connection_failure` (counter)
-  Could not connect to back-end data API, labelled by message
-- `api_service_exception` (counter)
-  The response from the back-end data API was not processed, labelled by message
-- `internal_application_error` (counter)
-  Unexpected events and internal error count, labelled by message
-- `memory_used_mb` (gauge)
-  Process memory usage in megabytes
-- `api_response_times` (histogram)
-  Histogram of response times of successful API calls.
+- `api_status` (counter) Response from data API, labelled by response status
+  code
+- `api_requests` (counter) Count of requests to the data API, labelled by result
+  success/failure
+- `api_connection_failure` (counter) Could not connect to back-end data API,
+  labelled by message
+- `api_service_exception` (counter) The response from the back-end data API was
+  not processed, labelled by message
+- `internal_application_error` (counter) Unexpected events and internal error
+  count, labelled by message
+- `memory_used_mb` (gauge) Process memory usage in megabytes
+- `api_response_times` (histogram) Histogram of response times of successful API
+  calls.
 
 Internally, we use ActiveSupport Notifications to emit events which are
-monitored and collected by the Prometheus store. Relevant pieces of the
-app include:
+monitored and collected by the Prometheus store. Relevant pieces of the app
+include:
 
-- `config/initializers/prometheus.rb`
-  Defines the Prometheus counters that the app knows about, and registers them
-  in the metrics store (see above)
-- `config/initializers/load_notification_subscribers.rb`
-  Some boiler-plate code to ensure that all of the notification subscribers
-  are loaded when the app starts
-- `app/subscribers`
-  Folder where the subscribers to the known ActiveSupport notifications are
-  defined. This is where the transform from `ActiveSupport::Notification` to
-  Prometheus counter or gauge is performed.
+- `config/initializers/prometheus.rb` Defines the Prometheus counters that the
+  app knows about, and registers them in the metrics store (see above)
+- `config/initializers/load_notification_subscribers.rb` Some boiler-plate code
+  to ensure that all of the notification subscribers are loaded when the app
+  starts
+- `app/subscribers` Folder where the subscribers to the known ActiveSupport
+  notifications are defined. This is where the transform from
+  `ActiveSupport::Notification` to Prometheus counter or gauge is performed.
 
-In addition to the metrics we define, there is a collection of standard
-metrics provided automatically by the
-[Ruby Prometheus client](https://github.com/prometheus/client_ruby)
+In addition to the metrics we define, there is a collection of standard metrics
+provided automatically by the [Ruby Prometheus
+client](https://github.com/prometheus/client_ruby)
 
 To test Prometheus when developing locally, there needs to be a Prometheus
-server running. Tip for Linux users: do not install the Prometheus apt
-package. This starts a locally running daemon with a pre-defined
-configuration, which is useful when monitoring the machine on which the
-server is running. A better approach for testing Prometheus is to
-[download](https://prometheus.io/download/) the server package and
-run it locally, with a suitable configuration. A basic config for
-monitoring a Rails application is provided in `test/prometheus/dev.yml`.
+server running. Tip for Linux users: do not install the Prometheus apt package.
+This starts a locally running daemon with a pre-defined configuration, which is
+useful when monitoring the machine on which the server is running. A better
+approach for testing Prometheus is to
+[download](https://prometheus.io/download/) the server package and run it
+locally, with a suitable configuration. A basic config for monitoring a Rails
+application is provided in `test/prometheus/dev.yml`.
 
-Using this approach, and assuming you install your local copy of
-Prometheus into `~/apps`, a starting command line would be something like:
+Using this approach, and assuming you install your local copy of Prometheus into
+`~/apps`, a starting command line would be something like:
 
 ```sh
 ~/apps/prometheus/prometheus-2.32.1.linux-amd64/prometheus \
@@ -250,15 +286,42 @@ Prometheus into `~/apps`, a starting command line would be something like:
 
 Something roughly equivalent should be possible on Windows and Mac as well.
 
+## Issues
 
-We use a number of environment variables to determine the runtime behaviour
-of the application:
+Please add issues to the [shared issues
+list](https://github.com/epimorphics/hmlr-linked-data/issues)
 
-| name                       | description                                                          | typical value              |
-| -------------------------- | -------------------------------------------------------------------- | -------------------------- |
-| `APPLICATION_ROOT`         | The path from the server root to the application                     | `/app/ppd`                 |
-| `API_SERVICE_URL`          | The base URL from which data is accessed, including the HTTP scheme  | `http://localhost:8080`    |
-| `SENTRY_API_KEY`           | The DSN for sending reports to the PPD Sentry account                |                            |
+## Additional Information
+
+### Deployment
+
+The detailed deployment mapping is described in `deployment.yml`. At the time of
+writing, using the new infrastructure, the deployment process is as follows:
+
+- commits to the `dev-infrastructure` branch will deploy the dev server
+- commits to the `preprod` branch will deploy the pre-production server
+- any commit on the `prod` branch will deploy the production server as a new
+  release
+
+If the commit is a "new" release, the deployment should be tagged with the same
+semantic version number matching the  `BREAKING.FEATURE.PATCH` format, e.g.
+`v1.2.3`, the same as should be set in the `/app/lib/version.rb`; also, a short
+annotation summarising the updates should be included in the tag as well.
+
+Once the production deployment has been completed and verified, please create a
+release on the repository using the same semantic version number. Utilise the
+`Generate release notes from commit log` option to create specific notes on the
+contained changes as well as the ability to diff agains the previous version.
+
+#### `entrypoint.sh` features
+
+- Workaround to removing the PID lock of the Rails process in the event of the
+  application crashing and not releasing the process.
+- Guards to ensure the required environment variables are set accordingly and
+  trigger the build to fail noisily and log to the system.
+- Rails secret creation for `SECRET_KEY_BASE` assignment; see [Runtime
+  Configuration environment
+  variables](#runtime-configuration-environment-variables).
 
 [^1]: With Docker 1.13.0 or greater, you can configure Docker to use different
 credential helpers for different registries.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,9 +23,7 @@ class ApplicationController < ActionController::Base
 
   unless Rails.application.config.consider_all_requests_local
     rescue_from Exception, with: :render_exception
-    rescue_from ActiveRecord::RecordNotFound, with: :render404
     rescue_from ActionController::RoutingError, with: :render404
-    rescue_from ActionController::UnknownController, with: :render404
     rescue_from ActionController::InvalidCrossOriginRequest, with: :render403
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,9 +15,9 @@ class ApplicationController < ActionController::Base
 
   around_action :log_request_result
   def log_request_result
-    start = Time.now
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
     yield
-    duration = Time.now - start
+    duration = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond) - start
     detailed_request_log(duration)
   end
 
@@ -68,11 +68,11 @@ class ApplicationController < ActionController::Base
     self.response_body = nil
   end
 
-  def detailed_request_log(duration) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+  def detailed_request_log(duration) # rubocop:disable Metrics/MethodLength
     env = request.env
 
     log_fields = {
-      timeTakenMS: duration * 1_000,
+      duration: duration,
       requestPath: env['REQUEST_PATH'],
       queryString: env['QUERY_STRING'],
       httpUserAgent: env['HTTP_USER_AGENT'],

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,9 +22,11 @@ class ApplicationController < ActionController::Base
   end
 
   unless Rails.application.config.consider_all_requests_local
-    rescue_from ActionController::RoutingError, with: :render404
-    rescue_from ActionController::InvalidCrossOriginRequest, with: :render403
     rescue_from Exception, with: :render_exception
+    rescue_from ActiveRecord::RecordNotFound, with: :render404
+    rescue_from ActionController::RoutingError, with: :render404
+    rescue_from ActionController::UnknownController, with: :render404
+    rescue_from ActionController::InvalidCrossOriginRequest, with: :render403
   end
 
   def render_exception(exception)
@@ -59,7 +61,7 @@ class ApplicationController < ActionController::Base
   end
 
   def render_html_error_page(status)
-    render(layout: false,
+    render(layout: true,
            file: Rails.root.join('public', 'landing', status.to_s),
            status: status)
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -47,6 +47,7 @@ class SearchController < ApplicationController
 
   private
 
+  # rubocop:disable Layout/LineLength
   def render_error_page(err, message, status, template = 'ppd/error')
     uuid = SecureRandom.uuid
 
@@ -54,7 +55,9 @@ class SearchController < ApplicationController
 
     @error_message =
       ["<p class='error bg-warning'>#{message}.</p>",
-       "<p>The log file reference for this error is<span class='sr-only'> Code</span>: <code>#{uuid}</code></p>"].join().html_safe
+       "<p>The log file reference for this error is<span class='sr-only'> Code</span>: <code>#{uuid}</code></p>",
+       '<p>You can quote this reference to support staff so that they can investigate this specific incident.</p>'].join.html_safe
     render(template: template, status: status)
   end
+  # rubocop:enable Layout/LineLength
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -51,8 +51,8 @@ class SearchController < ApplicationController
     Rails.logger.error "#{err.class.name} error #{uuid} ::: #{message} ::: #{err.class}"
 
     @error_message =
-      ["<span class='error bg-warning'>#{message}.</span>",
-       "The log file reference for this error is: #{uuid}."].join('<br />').html_safe
+      ["<p class='error bg-warning'>#{message}.</p>",
+       "<p>The log file reference for this error is<span class='sr-only'> Code</span>: <code>#{uuid}</code></p>"].join().html_safe
     render(template: template, status: status)
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,7 +8,8 @@ class SearchController < ApplicationController
     create
   end
 
-  def create # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
+  def create
     @preferences = UserPreferences.new(params)
 
     if @preferences.empty?
@@ -29,11 +30,12 @@ class SearchController < ApplicationController
              when MalformedSearchError, ArgumentError
                400
              else
-               500
+               e.status || 500
              end
 
     render_error_page(e, e.message, status)
   end
+  # rubocop:enable Metrics/MethodLength, Metrics/PerceivedComplexity
 
   def use_compact_json?
     !non_compact_formats.include?(request.format)

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,6 +3,7 @@
 module Version
   MAJOR = 1
   MINOR = 7
-  REVISION = 0
-  VERSION = "#{MAJOR}.#{MINOR}.#{REVISION}"
+  PATCH = 1
+  SUFFIX = nil
+  VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/app/views/ppd/error.html.haml
+++ b/app/views/ppd/error.html.haml
@@ -11,7 +11,7 @@
     %strong
       Things you can try:
 
-  %ul
+  %ul.error--checklist
     %li
       Make the query more selective. For example, add values for some of the other search
       fields, such as county, postcode or street. In particular, if you don't enter values for
@@ -35,6 +35,4 @@
     %a{ href: "/index.html#contact-us"}
       contact us.
 
-  %p
-    = @error_message
-    You can quote this number to support staff so that they can investigate this specific incident.
+  = @error_message

--- a/app/views/ppd/error.html.haml
+++ b/app/views/ppd/error.html.haml
@@ -35,4 +35,5 @@
     %a{ href: "/index.html#contact-us"}
       contact us.
 
-  = @error_message
+  %p
+    = @error_message

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,25 @@ require 'rails/test_unit/railtie'
 # you've limited to :test, :development, or :production.
 Bundler.require(:default, Rails.env)
 
+module PpdExplorer
+  # :nodoc:
+  class Application < Rails::Application
+    # Settings in config/environments/* take precedence over those specified here.
+    # Application configuration should go into files in config/initializers
+    # -- all .rb files in that directory are automatically loaded.
+
+    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
+    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
+    # config.time_zone = 'Central Time (US & Canada)'
+
+    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
+    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
+    # config.i18n.default_locale = :de
+
+    config.assets.paths << Rails.root.join('app', 'assets', 'fonts')
+  end
+end
+
 # Monkey-patch the bit of Rails that emits the start-up log message, so that it
 # is written out in JSON format that our combined logging service can handle
 # This version is Rails 5.x specific. A different pattern is needed for Rails 6
@@ -31,24 +50,5 @@ module Rails
       }
       puts msg.to_json
     end
-  end
-end
-
-module PpdExplorer
-  # :nodoc:
-  class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
-
-    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
-
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
-
-    config.assets.paths << Rails.root.join('app', 'assets', 'fonts')
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,13 @@ PpdExplorer::Application.configure do
   $stdout.sync = true
   config.logger = JsonRailsLogger::Logger.new($stdout)
 
-  config.api_service_url = ENV['API_SERVICE_URL'] || 'http://localhost:8080'
+  # Application Path can be specified in the entrypoint.sh script
+  # but falls back to a standard root value in development
+  config.relative_url_root = ENV.fetch('APPLICATION_PATH', '/')
+
+  # API location can be specified in the entrypoint.sh script
+  # but falls back to the local dev service
+  config.api_service_url = ENV.fetch('API_SERVICE_URL', 'http://localhost:8080')
 
   config.accessibility_document_path = '/doc/accessibility'
   config.privacy_document_path = '/doc/privacy'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,18 +46,14 @@ PpdExplorer::Application.configure do
   # Log the stdout output to the Epimorphics JSON logging gem
   config.logger = JsonRailsLogger::Logger.new($stdout)
 
-  # The RAILS_RELATIVE_URL_ROOT should be specified in the entrypoint.sh script
-  # but this passes in a standard root value in development if the app is run
-  # directly via `rails server`
+  # By default Rails expects that your application is running at the root (e.g. /).
+  # This configuration sets running your application inside a directory.
+  # Rails needs to know this directory to generate the appropriate routes.
+  # Alternatively you can set the RAILS_RELATIVE_URL_ROOT environment variable.
   config.relative_url_root = ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/')
 
-  # API_SERVICE_URL should also be specified in the entrypoint.sh file and
-  # set in the Makefile as an env variable for the docker container when run as an image.
-  # API_SERVICE_URL is required by both Docker image and Rails
-  
-  # API location can be specified in the environment
-  # But defaults to the dev service
-  config.api_service_url = ENV.fetch('API_SERVICE_URL', 'http://localhost:8080')
+  # API location can be specified in the environment but defaults to the dev service
+  config.api_service_url = ENV.fetch('API_SERVICE_URL', 'http://localhost:8888')
 
   # Use default paths for documentation.
   config.accessibility_document_path = '/doc/accessibility'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,9 +33,9 @@ PpdExplorer::Application.configure do
   $stdout.sync = true
   config.logger = JsonRailsLogger::Logger.new($stdout)
 
-  # Application Path can be specified in the entrypoint.sh script
+  # The application path can be specified in the entrypoint.sh script
   # but falls back to a standard root value in development
-  config.relative_url_root = ENV.fetch('APPLICATION_PATH', '/')
+  config.relative_url_root = ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/')
 
   # API location can be specified in the entrypoint.sh script
   # but falls back to the local dev service

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,23 +26,43 @@ PpdExplorer::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
+  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
+  # yet still be able to expire them through the digest params.
+  config.assets.digest = true
+
+  # Adds additional error checking when serving assets at runtime.
+  # Checks for improperly declared sprockets dependencies.
+  # Raises helpful error messages.
+  config.assets.raise_runtime_errors = true
+
   # Don't print a log message every time an asset file is loaded
   config.assets.quiet = true
 
+  # Tag rails logs with useful information
   config.log_tags = %i[subdomain request_id request_method]
+  # When sync mode is true, all output is immediately flushed to the underlying
+  # operating system and is not buffered by Ruby internally.
   $stdout.sync = true
+  # Log the stdout output to the Epimorphics JSON logging gem
   config.logger = JsonRailsLogger::Logger.new($stdout)
 
-  # The application path can be specified in the entrypoint.sh script
-  # but falls back to a standard root value in development
+  # The RAILS_RELATIVE_URL_ROOT should be specified in the entrypoint.sh script
+  # but this passes in a standard root value in development if the app is run
+  # directly via `rails server`
   config.relative_url_root = ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/')
 
-  # API location can be specified in the entrypoint.sh script
-  # but falls back to the local dev service
+  # API_SERVICE_URL should also be specified in the entrypoint.sh file and
+  # set in the Makefile as an env variable for the docker container when run as an image.
+  # API_SERVICE_URL is required by both Docker image and Rails
+  
+  # API location can be specified in the environment
+  # But defaults to the dev service
   config.api_service_url = ENV.fetch('API_SERVICE_URL', 'http://localhost:8080')
 
+  # Use default paths for documentation.
   config.accessibility_document_path = '/doc/accessibility'
   config.privacy_document_path = '/doc/privacy'
 
+  # Set the contact email address to Land Registry supplied address
   config.contact_email_address = 'data.services@mail.landregistry.gov.uk'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,12 +80,12 @@ PpdExplorer::Application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  # The RAILS_RELATIVE_URL_ROOT env var should NOT be used in Production
-  # The default value is passed in as the compiled assets have no knowledge of
-  # the base path and utilise the config.relative_url_root value to prefix the
+  # The RAILS_RELATIVE_URL_ROOT env var should ONLY be used in a local environment.
+  # Here, the default value is passed in as the compiled assets have no knowledge
+  # of the base path and utilise the config.relative_url_root value to prefix the
   # compiled asset paths
   config.relative_url_root = ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/app/ppd')
-  
+
   # API_SERVICE_URL should also be specified in the entrypoint.sh file and
   # set in the Makefile as an env variable for the docker container when run as an image.
   # API_SERVICE_URL is required by both Docker image and Rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,11 +96,11 @@ PpdExplorer::Application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   # config.log_formatter = ::Logger::Formatter.new
 
-  # Application Path should be specified in the entrypoint.sh file and therefore
+  # The application root should be specified in the entrypoint.sh file and therefore
   # in Production no fall back values are passed on the basis that missing
   # configuration options represent a category of bug, and in that case the
   # deployment should fail fast and noisily.
-  config.relative_url_root = ENV['APPLICATION_PATH']
+  config.relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT']
   # API location should also be specified in the entrypoint.sh file
   config.api_service_url = ENV['API_SERVICE_URL']
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,11 +96,13 @@ PpdExplorer::Application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   # config.log_formatter = ::Logger::Formatter.new
 
-  # In Production no default values are passed on the basis that missing
+  # Application Path should be specified in the entrypoint.sh file and therefore
+  # in Production no fall back values are passed on the basis that missing
   # configuration options represent a category of bug, and in that case the
   # deployment should fail fast and noisily.
-  config.relative_url_root = ENV.fetch('RAILS_RELATIVE_URL_ROOT')
-  config.api_service_url = ENV.fetch('API_SERVICE_URL')
+  config.relative_url_root = ENV['APPLICATION_PATH']
+  # API location should also be specified in the entrypoint.sh file
+  config.api_service_url = ENV['API_SERVICE_URL']
 
   # Use default paths for documentation.
   config.accessibility_document_path = '/accessibility'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,6 +61,17 @@ PpdExplorer::Application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
+  # * Set cache control headers for HMLR apps to be public and cacheable
+  # * Price Paid Data uses a time limit of 5 minutes (300 seconds)
+  # This will affect assets served from /app/assets
+  config.static_cache_control = "public, max-age=#{5.minutes.to_i}"
+
+  # This will affect assets in /public, e.g. webpacker assets.
+  config.public_file_server.headers = {
+    'Cache-Control' => "public, max-age=#{5.minutes.to_i}",
+    'Expires' => 5.minutes.from_now.to_formatted_s(:rfc822)
+  }
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = "http://assets.example.com"
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ PpdExplorer::Application.configure do
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
   # config.serve_static_assets = false
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'] || true
+  config.serve_static_files = ENV.fetch('RAILS_SERVE_STATIC_FILES', true)
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -96,13 +96,13 @@ PpdExplorer::Application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   # config.log_formatter = ::Logger::Formatter.new
 
-  # Specify that we're not at the root
-  config.relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT'] || '/'
+  # In Production no default values are passed on the basis that missing
+  # configuration options represent a category of bug, and in that case the
+  # deployment should fail fast and noisily.
+  config.relative_url_root = ENV.fetch('RAILS_RELATIVE_URL_ROOT')
+  config.api_service_url = ENV.fetch('API_SERVICE_URL')
 
-  # API location can be specified in the environment
-  # But defaults to the dev service
-  config.api_service_url = ENV['API_SERVICE_URL'] || 'http://localhost:8080'
-
+  # Use default paths for documentation.
   config.accessibility_document_path = '/accessibility'
   config.privacy_document_path = '/privacy'
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'syslog/logger'
-
 PpdExplorer::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -9,7 +7,7 @@ PpdExplorer::Application.configure do
   config.cache_classes = true
 
   # Eager load code on boot. This eager loads most of Rails and
-  # your application in memory, allowing both thread web servers
+  # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.
   # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
@@ -20,12 +18,13 @@ PpdExplorer::Application.configure do
 
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
   # Add `rack-cache` to your Gemfile before enabling this.
-  # For large-scale production use, consider using a caching reverse proxy
+  # For large-scale production use, consider using a caching reverse proxy like
+  # NGINX, varnish or squid.
   # config.action_dispatch.rack_cache = true
 
-  # Disable Rails's static asset server (Apache or nginx will already do this).
-  # config.serve_static_assets = false
-  config.serve_static_files = ENV.fetch('RAILS_SERVE_STATIC_FILES', true)
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV.fetch('RAILS_SERVE_STATIC_FILES', true)
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -34,28 +33,26 @@ PpdExplorer::Application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # Generate digests for assets URLs.
+  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
+  # yet still be able to expire them through the digest params.
   config.assets.digest = true
 
-  # Version of your assets, change this if you want to expire all your assets.
-  config.assets.version = '1.0'
+  # `config.assets.precompile` and `config.assets.version` have moved to
+  # config/initializers/assets.rb
 
   # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Set to :debug to see everything in the log.
-  config.log_level = :info
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = %i[subdomain request_id]
-
-  # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new)
+  # Tag rails logs with useful information
+  config.log_tags = %i[subdomain request_id request_method]
+  # When sync mode is true, all output is immediately flushed to the underlying
+  # operating system and is not buffered by Ruby internally.
   $stdout.sync = true
+  # Log the stdout output to the Epimorphics JSON logging gem
   config.logger = JsonRailsLogger::Logger.new($stdout)
 
   # Use a different cache store in production.
@@ -72,13 +69,6 @@ PpdExplorer::Application.configure do
     'Expires' => 5.minutes.from_now.to_formatted_s(:rfc822)
   }
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = "http://assets.example.com"
-
-  # Precompile additional assets.
-  # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-  # config.assets.precompile += %w( search.js )
-
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
@@ -90,23 +80,21 @@ PpdExplorer::Application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  # Disable automatic flushing of the log to improve performance.
-  # config.autoflush_log = false
-
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  # config.log_formatter = ::Logger::Formatter.new
-
-  # The application root should be specified in the entrypoint.sh file and therefore
-  # in Production no fall back values are passed on the basis that missing
-  # configuration options represent a category of bug, and in that case the
-  # deployment should fail fast and noisily.
-  config.relative_url_root = ENV['RAILS_RELATIVE_URL_ROOT']
-  # API location should also be specified in the entrypoint.sh file
+  # The RAILS_RELATIVE_URL_ROOT env var should NOT be used in Production
+  # The default value is passed in as the compiled assets have no knowledge of
+  # the base path and utilise the config.relative_url_root value to prefix the
+  # compiled asset paths
+  config.relative_url_root = '/app/ppd'
+  
+  # API_SERVICE_URL should also be specified in the entrypoint.sh file and
+  # set in the Makefile as an env variable for the docker container when run as an image.
+  # API_SERVICE_URL is required by both Docker image and Rails
   config.api_service_url = ENV['API_SERVICE_URL']
 
   # Use default paths for documentation.
   config.accessibility_document_path = '/accessibility'
   config.privacy_document_path = '/privacy'
 
+  # Set the contact email address to Land Registry supplied address
   config.contact_email_address = 'data.services@mail.landregistry.gov.uk'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,15 +7,15 @@ PpdExplorer::Application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
 
-  # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets = true
+  # Configure static file server for tests with Cache-Control for performance.
+  config.public_file_server.enabled = true
   config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Show full error reports and disable caching.
@@ -36,12 +36,22 @@ PpdExplorer::Application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  # Tag rails logs with useful information
+  config.log_tags = %i[subdomain request_id request_method]
+  # When sync mode is true, all output is immediately flushed to the underlying
+  # operating system and is not buffered by Ruby internally.
+  $stdout.sync = true
+  # Log the stdout output to the Epimorphics JSON logging gem
+  config.logger = JsonRailsLogger::Logger.new($stdout)
+
   # API location can be specified in the environment
   # But defaults to the dev service
-  config.api_service_url = ENV['API_SERVICE_URL'] || 'http://localhost:8080'
+  config.api_service_url = ENV.fetch('API_SERVICE_URL', 'http://localhost:8080')
 
+  # Use default paths for documentation.
   config.accessibility_document_path = '/doc/accessibility'
   config.privacy_document_path = '/doc/privacy'
 
+  # Set the contact email address to Land Registry supplied address
   config.contact_email_address = 'data.services@mail.landregistry.gov.uk'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,7 +46,7 @@ PpdExplorer::Application.configure do
 
   # API location can be specified in the environment
   # But defaults to the dev service
-  config.api_service_url = ENV.fetch('API_SERVICE_URL', 'http://localhost:8080')
+  config.api_service_url = ENV.fetch('API_SERVICE_URL', 'http://localhost:8888')
 
   # Use default paths for documentation.
   config.accessibility_document_path = '/doc/accessibility'

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,4 +1,14 @@
 # frozen_string_literal: true
 
+# Be sure to restart your server when you modify this file.
+
+# Version of your assets, change this if you want to expire all your assets.
+Rails.application.config.assets.version = '1.0'
+
+# Add additional assets to the asset load path
+# Rails.application.config.assets.paths << Emoji.images_path
+
+# Precompile additional assets.
+# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 Rails.application.config.assets.precompile += %w[hm_lr_logo.svg]
 Rails.application.config.assets.precompile += %w[hm_lr_logo.png]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,14 +13,14 @@ fi
 
 [ -z "API_SERVICE_URL" ] && echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified env var API_SERVICE_URL', 'level': 'ERROR'}}" >&2
 
-[ -z "APPLICATION_PATH" ] && echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified env var APPLICATION_PATH', 'level': 'ERROR'}}" >&2
+[ -z "APPLICATION_ROOT" ] && echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified env var APPLICATION_ROOT', 'level': 'ERROR'}}" >&2
 
-if [ -z "API_SERVICE_URL" ] || [-z "APPLICATION_PATH"]
+if [ -z "API_SERVICE_URL" ] || [-z "APPLICATION_ROOT"]
 then
   exit 1
 fi
 
-echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'PPD starting with API_SERVICE_URL ${API_SERVICE_URL} at APPLICATION_PATH ${APPLICATION_PATH}', 'level': 'INFO'}}"
+echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'PPD starting with API_SERVICE_URL ${API_SERVICE_URL} at APPLICATION_ROOT ${APPLICATION_ROOT}', 'level': 'INFO'}}"
 
 # Handle secrets based on env
 if [ "$RAILS_ENV" == "production" ] && [ -z "$SECRET_KEY_BASE" ]
@@ -28,7 +28,7 @@ then
   export SECRET_KEY_BASE=`./bin/rails secret`
 fi
 
-export APPLICATION_PATH=${APPLICATION_PATH:-'/app/ppd'}
-export SCRIPT_NAME=${APPLICATION_PATH}
+export RAILS_RELATIVE_URL_ROOT=${APPLICATION_ROOT:-'/app/ppd'}
+export SCRIPT_NAME=${APPLICATION_ROOT}
 
 exec ./bin/rails server -e ${RAILS_ENV} -b 0.0.0.0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,13 +11,16 @@ then
   export RAILS_ENV=production
 fi
 
-if [ -z "API_SERVICE_URL" ]
+[ -z "API_SERVICE_URL" ] && echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified env var API_SERVICE_URL', 'level': 'ERROR'}}" >&2
+
+[ -z "APPLICATION_PATH" ] && echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified env var APPLICATION_PATH', 'level': 'ERROR'}}" >&2
+
+if [ -z "API_SERVICE_URL" ] || [-z "APPLICATION_PATH"]
 then
-  echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified an API_SERVICE_URL', 'level': 'ERROR'}}" >&2
   exit 1
 fi
 
-echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'PPD starting with API_SERVICE_URL ${API_SERVICE_URL}', 'level': 'INFO'}}"
+echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'PPD starting with API_SERVICE_URL ${API_SERVICE_URL} at APPLICATION_PATH ${APPLICATION_PATH}', 'level': 'INFO'}}"
 
 # Handle secrets based on env
 if [ "$RAILS_ENV" == "production" ] && [ -z "$SECRET_KEY_BASE" ]
@@ -25,7 +28,7 @@ then
   export SECRET_KEY_BASE=`./bin/rails secret`
 fi
 
-export RAILS_RELATIVE_URL_ROOT=${RAILS_RELATIVE_URL_ROOT:-'/app/ppd'}
-export SCRIPT_NAME=${RAILS_RELATIVE_URL_ROOT}
+export APPLICATION_PATH=${APPLICATION_PATH:-'/app/ppd'}
+export SCRIPT_NAME=${APPLICATION_PATH}
 
 exec ./bin/rails server -e ${RAILS_ENV} -b 0.0.0.0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,30 +5,35 @@ set -e
 rm -f ./tmp/pids/server.pid
 mkdir -pm 1777 ./tmp
 
+# This is set to the name of the application for logging purposes
+PUBLIC_NAME="PPD Explorer"
+
 # Set the environment
 if [ -z "$RAILS_ENV" ]
 then
   export RAILS_ENV=production
 fi
 
-[ -z "API_SERVICE_URL" ] && echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified env var API_SERVICE_URL', 'level': 'ERROR'}}" >&2
 
-[ -z "APPLICATION_ROOT" ] && echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'You have not specified env var APPLICATION_ROOT', 'level': 'ERROR'}}" >&2
+echo "{\"ts\": $(date -u +%FT%T.%3NZ), \"level\": \"INFO\", \"message\": \"Initiating ${PUBLIC_NAME} application using APPLICATION_ROOT=${APPLICATION_ROOT}, API_SERVICE_URL=${API_SERVICE_URL}}"
 
-if [ -z "API_SERVICE_URL" ] || [-z "APPLICATION_ROOT"]
+if [ -z "$API_SERVICE_URL" ]
 then
+  echo "{\"ts\": $(date -u +%FT%T.%3NZ), \"level\": \"ERROR\", \"message\": \"You have not specified the env var API_SERVICE_URL\"}" >&2
   exit 1
 fi
 
-echo "{'ts': '`date -u +%FT%T.%3NZ`', 'message': {'text: 'PPD starting with API_SERVICE_URL ${API_SERVICE_URL} at APPLICATION_ROOT ${APPLICATION_ROOT}', 'level': 'INFO'}}"
 
 # Handle secrets based on env
 if [ "$RAILS_ENV" == "production" ] && [ -z "$SECRET_KEY_BASE" ]
 then
-  export SECRET_KEY_BASE=`./bin/rails secret`
+  SECRET_KEY_BASE=$(./bin/rails secret)
+  export SECRET_KEY_BASE
 fi
 
 export RAILS_RELATIVE_URL_ROOT=${APPLICATION_ROOT:-'/app/ppd'}
-export SCRIPT_NAME=${APPLICATION_ROOT}
+export SCRIPT_NAME=${RAILS_RELATIVE_URL_ROOT}
 
-exec ./bin/rails server -e ${RAILS_ENV} -b 0.0.0.0
+echo "{\"ts\": $(date -u +%FT%T.%3NZ), \"level\": \"INFO\", \"message\": \"Starting ${PUBLIC_NAME} application with RAILS_ENV=\"${RAILS_ENV}\", \"RAILS_RELATIVE_URL_ROOT\"=\"${RAILS_RELATIVE_URL_ROOT}\", \"SCRIPT_NAME\"=\"${SCRIPT_NAME}\"}"
+
+exec ./bin/rails server -e "${RAILS_ENV}" -b 0.0.0.0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,34 +5,20 @@ set -e
 rm -f ./tmp/pids/server.pid
 mkdir -pm 1777 ./tmp
 
-# This is set to the name of the application for logging purposes
-PUBLIC_NAME="PPD Explorer"
-
 # Set the environment
 [ -z "$RAILS_ENV" ] && RAILS_ENV=production
 
+# Check for API Service URL variable and log it
+[ -n "$API_SERVICE_URL" ] && echo "{\"ts\":\"$(date -u +%FT%T.%3NZ)\",\"level\":\"INFO\",\"message\":\"API_SERVICE_URL=${API_SERVICE_URL}\"}"
 
-echo "{\"ts\": $(date -u +%FT%T.%3NZ), \"level\": \"INFO\", \"message\": \"Initiating ${PUBLIC_NAME} application using APPLICATION_ROOT=${APPLICATION_ROOT}, API_SERVICE_URL=${API_SERVICE_URL}}"
-
-if [ -z "$API_SERVICE_URL" ]
-then
-  echo "{\"ts\": $(date -u +%FT%T.%3NZ), \"level\": \"ERROR\", \"message\": \"You have not specified the env var API_SERVICE_URL\"}" >&2
-  exit 1
-else
-  echo "{\"ts\":\"$(date -u +%FT%T.%3NZ)\",\"level\":\"INFO\",\"message\":\"API_SERVICE_URL=${API_SERVICE_URL}\"}"
-fi
-
+# Check for RAILS_RELATIVE_URL_ROOT variable and log it
+[ -n "$RAILS_RELATIVE_URL_ROOT" ] && echo "{\"ts\":\"$(date -u +%FT%T.%3NZ)\",\"level\":\"INFO\",\"message\":\"RAILS_RELATIVE_URL_ROOT=${RAILS_RELATIVE_URL_ROOT}\"}"
 
 # Handle secrets based on env
-if [ "$RAILS_ENV" == "production" ] && [ -z "$SECRET_KEY_BASE" ]
-then
-  SECRET_KEY_BASE=$(./bin/rails secret)
-  export SECRET_KEY_BASE
-fi
+[ "$RAILS_ENV" == "production" ] && [ -z "$SECRET_KEY_BASE" ] && SECRET_KEY_BASE=$(./bin/rails secret) && export SECRET_KEY_BASE
 
-export RAILS_RELATIVE_URL_ROOT=${APPLICATION_ROOT:-'/app/ppd'}
-export SCRIPT_NAME=${RAILS_RELATIVE_URL_ROOT}
+# Log the rails command that will be executed
+echo "{\"ts\":\"$(date -u +%FT%T.%3NZ)\",\"level\":\"INFO\",\"message\":\"exec ./bin/rails server -e ${RAILS_ENV} -b 0.0.0.0\"}"
 
-echo "{\"ts\": $(date -u +%FT%T.%3NZ), \"level\": \"INFO\", \"message\": \"Starting ${PUBLIC_NAME} application with RAILS_ENV=\"${RAILS_ENV}\", \"RAILS_RELATIVE_URL_ROOT\"=\"${RAILS_RELATIVE_URL_ROOT}\", \"SCRIPT_NAME\"=\"${SCRIPT_NAME}\"}"
-
+# Execute the rails command
 exec ./bin/rails server -e "${RAILS_ENV}" -b 0.0.0.0

--- a/public/landing/400.html
+++ b/public/landing/400.html
@@ -1,116 +1,26 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset='utf-8'>
-    <title>
-      Land Registry Open Data &ndash; page not found
-    </title>
-    <link rel="stylesheet" href="/stylesheets/landing.css" type="text/css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" type="text/css">
-    <link href="/images/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />
-    <meta name="Description" content="Linked Open Data resources from the Land Registry"/>
-    <meta name="Monitoring" content="Confirming site availability." />
-  </head>
-  <body class='government website lr hpi'>
-    <script type="text/javascript">
-document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
-    <header class='container with-proposition' id='global-header'>
-      <div class="row">
-        <div class='header-wrapper'>
-          <div class='header-global pull-left'>
-            <div class='header-logo'>
-              <a href="https://www.gov.uk/government/organisations/land-registry" class='content'><img src="/images/lr_logo_221_80.png"></a>
-            </div>
-          </div>
-          <div class='header-proposition'>
-            <div class='content'>
-              <nav id='proposition-menu'>
-                <a id='proposition-name'>Land Registry Linked Open Data</a>
-                <div class='beta-tag'>
-                  beta
-                </div>
-                <ul id='proposition-links' class='list-inline'>
-                  <li>
-                    <a href="/app/hpi">House Price Index</a>
-                  </li>
-                  <li>
-                    <a href="/app/ppd">Price Paid Data</a>
-                  </li>
-                  <li>
-                    <a href="/app/hpi/qonsole">SPARQL query</a>
-                  </li>
-                </ul>
-              </nav>
-            </div>
-          </div>
-        </div>
-      </div>
-    </header>
-    <div class='lr-top-bar'></div>
-    <div class='container'>
-      <div class='row'>
-        <div class='col-md-12'>
-          <h1>
-            Request not understood
-          </h1>
-          <p>
-            We're sorry, but the request you made was not understood. If you are requesting data via a script
-            or program, please check the URL parameters. If you see this message as a result of using the HPI
-            or PPD applications, please let us know so that we can correct the problem.
-          </p>
-          <h2 id="contact-us">
-            Who to contact
-          </h2>
-          <p>
-            If you are unable to access the data please <a href="http://site.landregistry.gov.uk/contact-us/form">fill in our contact form</a>.
-          </p>
-          <p>
-            For general transaction data enquiries email <a href="mailto:DRO@landregistry.gov.uk">DRO@landregistry.gov.uk</a>
-          </p>
-          <p>
-            For general price paid data enquiries contact <a href="mailto:data.services@mail.landregistry.gov.uk">data.services@mail.landregistry.gov.uk</a>.
-          </p>
-        </div><!--/.col-md-12-->
-      </div>
-    </div> <!-- /.container -->
-    <footer id="footer" role="contentinfo">
-      <div class="container">
-        <h2 class="hidden">
-          Support links
-        </h2>
-        <ul class="list-inline">
-          <li>
-            <a href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown copyright 2014&ndash;2016</a>
-          </li>
-          <li>
-            <a href="https://www.gov.uk/government/organisations/land-registry/about/personal-information-charter">Personal Information Charter</a>
-          </li>
-          <li>
-            <a href="https://www.gov.uk/land-registry-public-data">Land Registry Public Data</a>
-          </li>
-        </ul>
-        <div class="ogl">
-          <h2 class="pull-left">
-            <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3"><img alt="OGL" src="https://assets.digital.cabinet-office.gov.uk/static/open-government-licence_2x-d273d7eca3045d3b710a863d9bfc0b33.png"></img></a>
-          </h2>
-          <p>
-            All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">Open Government Licence v3.0</a> except where otherwise stated
-          </p>
-        </div>
-        <div class="clearfix"></div>
-      </div>
-    </footer>
-    <script type="text/javascript">
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-21165003-6']);
-  _gaq.push(['_trackPageview']);
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-  </script>
-
-  </body>
-</html>
+<div class='row'>
+  <div class='col-md-12'>
+    <h1>
+      Request not understood
+    </h1>
+    <p>
+      We're sorry, but the request you made was not understood. If you are requesting data via a script
+      or program, please check the URL parameters. If you see this message as a result of using the HPI
+      or PPD applications, please let us know so that we can correct the problem.
+    </p>
+    <h2 id="contact-us">
+      Who to contact
+    </h2>
+    <p>
+      If you are unable to access the data please <a href="http://site.landregistry.gov.uk/contact-us/form">fill in our
+        contact form</a>.
+    </p>
+    <p>
+      For general transaction data enquiries email <a href="mailto:DRO@landregistry.gov.uk">DRO@landregistry.gov.uk</a>
+    </p>
+    <p>
+      For general price paid data enquiries contact <a
+        href="mailto:data.services@mail.landregistry.gov.uk">data.services@mail.landregistry.gov.uk</a>.
+    </p>
+  </div><!--/.col-md-12-->
+</div>

--- a/public/landing/400.html
+++ b/public/landing/400.html
@@ -1,26 +1,27 @@
-<div class='row'>
-  <div class='col-md-12'>
-    <h1>
-      Request not understood
-    </h1>
-    <p>
-      We're sorry, but the request you made was not understood. If you are requesting data via a script
-      or program, please check the URL parameters. If you see this message as a result of using the HPI
-      or PPD applications, please let us know so that we can correct the problem.
-    </p>
-    <h2 id="contact-us">
-      Who to contact
-    </h2>
-    <p>
-      If you are unable to access the data please <a href="http://site.landregistry.gov.uk/contact-us/form">fill in our
-        contact form</a>.
-    </p>
-    <p>
-      For general transaction data enquiries email <a href="mailto:DRO@landregistry.gov.uk">DRO@landregistry.gov.uk</a>
-    </p>
-    <p>
-      For general price paid data enquiries contact <a
-        href="mailto:data.services@mail.landregistry.gov.uk">data.services@mail.landregistry.gov.uk</a>.
-    </p>
-  </div><!--/.col-md-12-->
-</div>
+
+    <div class='container'>
+      <div class='row'>
+        <div class='col-md-12'>
+          <h1>
+            Request not understood
+          </h1>
+          <p>
+            We're sorry, but the request you made was not understood. If you are requesting data via a script
+            or program, please check the URL parameters. If you see this message as a result of using the HPI
+            or PPD applications, please let us know so that we can correct the problem.
+          </p>
+          <h2 id="contact-us">
+            Who to contact
+          </h2>
+          <p>
+            If you are unable to access the data please <a href="http://site.landregistry.gov.uk/contact-us/form">fill in our contact form</a>.
+          </p>
+          <p>
+            For general transaction data enquiries email <a href="mailto:DRO@landregistry.gov.uk">DRO@landregistry.gov.uk</a>
+          </p>
+          <p>
+            For general price paid data enquiries contact <a href="mailto:data.services@mail.landregistry.gov.uk">data.services@mail.landregistry.gov.uk</a>.
+          </p>
+        </div><!--/.col-md-12-->
+      </div>
+    </div> <!-- /.container -->

--- a/public/landing/404.html
+++ b/public/landing/404.html
@@ -1,25 +1,26 @@
-<div class='row'>
-  <div class='col-md-12'>
-    <h1>
-      Page not found
-    </h1>
-    <p>
-      We're sorry, but the web page you requested is not present on our server. Please check the spelling
-      of the page address (URL). If you require further assistance, please see the contact details below.
-    </p>
-    <h2 id="contact-us">
-      Who to contact
-    </h2>
-    <p>
-      If you are unable to access the data please <a href="http://site.landregistry.gov.uk/contact-us/form">fill in our
-        contact form</a>.
-    </p>
-    <p>
-      For general transaction data enquiries email <a href="mailto:DRO@landregistry.gov.uk">DRO@landregistry.gov.uk</a>
-    </p>
-    <p>
-      For general price paid data enquiries contact <a
-        href="mailto:data.services@mail.landregistry.gov.uk">data.services@mail.landregistry.gov.uk</a>.
-    </p>
-  </div><!--/.col-md-12-->
-</div>
+
+    <div class='container'>
+      <div class='row'>
+        <div class='col-md-12'>
+          <h1>
+            Page not found
+          </h1>
+          <p>
+            We're sorry, but the web page you requested is not present on our server. Please check the spelling
+            of the page address (URL). If you require further assistance, please see the contact details below.
+          </p>
+          <h2 id="contact-us">
+            Who to contact
+          </h2>
+          <p>
+            If you are unable to access the data please <a href="http://site.landregistry.gov.uk/contact-us/form">fill in our contact form</a>.
+          </p>
+          <p>
+            For general transaction data enquiries email <a href="mailto:DRO@landregistry.gov.uk">DRO@landregistry.gov.uk</a>
+          </p>
+          <p>
+            For general price paid data enquiries contact <a href="mailto:data.services@mail.landregistry.gov.uk">data.services@mail.landregistry.gov.uk</a>.
+          </p>
+        </div><!--/.col-md-12-->
+      </div>
+    </div> <!-- /.container -->

--- a/public/landing/404.html
+++ b/public/landing/404.html
@@ -1,115 +1,25 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset='utf-8'>
-    <title>
-      Land Registry Open Data &ndash; page not found
-    </title>
-    <link rel="stylesheet" href="/stylesheets/landing.css" type="text/css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" type="text/css">
-    <link href="/images/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />
-    <meta name="Description" content="Linked Open Data resources from the Land Registry"/>
-    <meta name="Monitoring" content="Confirming site availability." />
-  </head>
-  <body class='government website lr hpi'>
-    <script type="text/javascript">
-document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
-    <header class='container with-proposition' id='global-header'>
-      <div class="row">
-        <div class='header-wrapper'>
-          <div class='header-global pull-left'>
-            <div class='header-logo'>
-              <a href="https://www.gov.uk/government/organisations/land-registry" class='content'><img src="/images/lr_logo_221_80.png"></a>
-            </div>
-          </div>
-          <div class='header-proposition'>
-            <div class='content'>
-              <nav id='proposition-menu'>
-                <a id='proposition-name'>Land Registry Linked Open Data</a>
-                <div class='beta-tag'>
-                  beta
-                </div>
-                <ul id='proposition-links' class='list-inline'>
-                  <li>
-                    <a href="/app/hpi">House Price Index</a>
-                  </li>
-                  <li>
-                    <a href="/app/ppd">Price Paid Data</a>
-                  </li>
-                  <li>
-                    <a href="/app/hpi/qonsole">SPARQL query</a>
-                  </li>
-                </ul>
-              </nav>
-            </div>
-          </div>
-        </div>
-      </div>
-    </header>
-    <div class='lr-top-bar'></div>
-    <div class='container'>
-      <div class='row'>
-        <div class='col-md-12'>
-          <h1>
-            Page not found
-          </h1>
-          <p>
-            We're sorry, but the web page you requested is not present on our server. Please check the spelling
-            of the page address (URL). If you require further assistance, please see the contact details below.
-          </p>
-          <h2 id="contact-us">
-            Who to contact
-          </h2>
-          <p>
-            If you are unable to access the data please <a href="http://site.landregistry.gov.uk/contact-us/form">fill in our contact form</a>.
-          </p>
-          <p>
-            For general transaction data enquiries email <a href="mailto:DRO@landregistry.gov.uk">DRO@landregistry.gov.uk</a>
-          </p>
-          <p>
-            For general price paid data enquiries contact <a href="mailto:data.services@mail.landregistry.gov.uk">data.services@mail.landregistry.gov.uk</a>.
-          </p>
-        </div><!--/.col-md-12-->
-      </div>
-    </div> <!-- /.container -->
-    <footer id="footer" role="contentinfo">
-      <div class="container">
-        <h2 class="hidden">
-          Support links
-        </h2>
-        <ul class="list-inline">
-          <li>
-            <a href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown copyright 2014&ndash;2016</a>
-          </li>
-          <li>
-            <a href="https://www.gov.uk/government/organisations/land-registry/about/personal-information-charter">Personal Information Charter</a>
-          </li>
-          <li>
-            <a href="https://www.gov.uk/land-registry-public-data">Land Registry Public Data</a>
-          </li>
-        </ul>
-        <div class="ogl">
-          <h2 class="pull-left">
-            <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3"><img alt="OGL" src="https://assets.digital.cabinet-office.gov.uk/static/open-government-licence_2x-d273d7eca3045d3b710a863d9bfc0b33.png"></img></a>
-          </h2>
-          <p>
-            All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">Open Government Licence v3.0</a> except where otherwise stated
-          </p>
-        </div>
-        <div class="clearfix"></div>
-      </div>
-    </footer>
-    <script type="text/javascript">
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-21165003-6']);
-  _gaq.push(['_trackPageview']);
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-  </script>
-
-  </body>
-</html>
+<div class='row'>
+  <div class='col-md-12'>
+    <h1>
+      Page not found
+    </h1>
+    <p>
+      We're sorry, but the web page you requested is not present on our server. Please check the spelling
+      of the page address (URL). If you require further assistance, please see the contact details below.
+    </p>
+    <h2 id="contact-us">
+      Who to contact
+    </h2>
+    <p>
+      If you are unable to access the data please <a href="http://site.landregistry.gov.uk/contact-us/form">fill in our
+        contact form</a>.
+    </p>
+    <p>
+      For general transaction data enquiries email <a href="mailto:DRO@landregistry.gov.uk">DRO@landregistry.gov.uk</a>
+    </p>
+    <p>
+      For general price paid data enquiries contact <a
+        href="mailto:data.services@mail.landregistry.gov.uk">data.services@mail.landregistry.gov.uk</a>.
+    </p>
+  </div><!--/.col-md-12-->
+</div>

--- a/public/landing/500.html
+++ b/public/landing/500.html
@@ -1,26 +1,27 @@
-<div class='row'>
-  <div class='col-md-12'>
-    <h1>
-      Application error
-    </h1>
-    <p>
-      We're very sorry, but the request you just made resulted in an internal error in the application.
-      If this problem persists, please use one of the contact methods below to report the problem
-      to us, so that we can resolve it and help you get the data you require.
-    </p>
-    <h2 id="contact-us">
-      Who to contact
-    </h2>
-    <p>
-      If you are unable to access the data please <a href="http://site.landregistry.gov.uk/contact-us/form">fill in our
-        contact form</a>.
-    </p>
-    <p>
-      For general transaction data enquiries email <a href="mailto:DRO@landregistry.gov.uk">DRO@landregistry.gov.uk</a>
-    </p>
-    <p>
-      For general price paid data enquiries contact <a
-        href="mailto:data.services@mail.landregistry.gov.uk">data.services@mail.landregistry.gov.uk</a>.
-    </p>
-  </div><!--/.col-md-12-->
-</div>
+
+    <div class='container'>
+      <div class='row'>
+        <div class='col-md-12'>
+          <h1>
+            Application error
+          </h1>
+          <p>
+            We're very sorry, but the request you just made resulted in an internal error in the application.
+            If this problem persists, please use one of the contact methods below to report the problem
+            to us, so that we can resolve it and help you get the data you require.
+          </p>
+          <h2 id="contact-us">
+            Who to contact
+          </h2>
+          <p>
+            If you are unable to access the data please <a href="http://site.landregistry.gov.uk/contact-us/form">fill in our contact form</a>.
+          </p>
+          <p>
+            For general transaction data enquiries email <a href="mailto:DRO@landregistry.gov.uk">DRO@landregistry.gov.uk</a>
+          </p>
+          <p>
+            For general price paid data enquiries contact <a href="mailto:data.services@mail.landregistry.gov.uk">data.services@mail.landregistry.gov.uk</a>.
+          </p>
+        </div><!--/.col-md-12-->
+      </div>
+    </div> <!-- /.container -->

--- a/public/landing/500.html
+++ b/public/landing/500.html
@@ -1,116 +1,26 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset='utf-8'>
-    <title>
-      Land Registry Open Data &ndash; page not found
-    </title>
-    <link rel="stylesheet" href="/stylesheets/landing.css" type="text/css">
-    <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" type="text/css">
-    <link href="/images/favicon.ico" rel="shortcut icon" type="image/vnd.microsoft.icon" />
-    <meta name="Description" content="Linked Open Data resources from the Land Registry"/>
-    <meta name="Monitoring" content="Confirming site availability." />
-  </head>
-  <body class='government website lr hpi'>
-    <script type="text/javascript">
-document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
-    <header class='container with-proposition' id='global-header'>
-      <div class="row">
-        <div class='header-wrapper'>
-          <div class='header-global pull-left'>
-            <div class='header-logo'>
-              <a href="https://www.gov.uk/government/organisations/land-registry" class='content'><img src="/images/lr_logo_221_80.png"></a>
-            </div>
-          </div>
-          <div class='header-proposition'>
-            <div class='content'>
-              <nav id='proposition-menu'>
-                <a id='proposition-name'>Land Registry Linked Open Data</a>
-                <div class='beta-tag'>
-                  beta
-                </div>
-                <ul id='proposition-links' class='list-inline'>
-                  <li>
-                    <a href="/app/hpi">House Price Index</a>
-                  </li>
-                  <li>
-                    <a href="/app/ppd">Price Paid Data</a>
-                  </li>
-                  <li>
-                    <a href="/app/hpi/qonsole">SPARQL query</a>
-                  </li>
-                </ul>
-              </nav>
-            </div>
-          </div>
-        </div>
-      </div>
-    </header>
-    <div class='lr-top-bar'></div>
-    <div class='container'>
-      <div class='row'>
-        <div class='col-md-12'>
-          <h1>
-            Application error
-          </h1>
-          <p>
-            We're very sorry, but the request you just made resulted in an internal error in the application.
-            If this problem persists, please use one of the contact methods below to report the problem
-            to us, so that we can resolve it and help you get the data you require.
-          </p>
-          <h2 id="contact-us">
-            Who to contact
-          </h2>
-          <p>
-            If you are unable to access the data please <a href="http://site.landregistry.gov.uk/contact-us/form">fill in our contact form</a>.
-          </p>
-          <p>
-            For general transaction data enquiries email <a href="mailto:DRO@landregistry.gov.uk">DRO@landregistry.gov.uk</a>
-          </p>
-          <p>
-            For general price paid data enquiries contact <a href="mailto:data.services@mail.landregistry.gov.uk">data.services@mail.landregistry.gov.uk</a>.
-          </p>
-        </div><!--/.col-md-12-->
-      </div>
-    </div> <!-- /.container -->
-    <footer id="footer" role="contentinfo">
-      <div class="container">
-        <h2 class="hidden">
-          Support links
-        </h2>
-        <ul class="list-inline">
-          <li>
-            <a href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown copyright 2014&ndash;2016</a>
-          </li>
-          <li>
-            <a href="https://www.gov.uk/government/organisations/land-registry/about/personal-information-charter">Personal Information Charter</a>
-          </li>
-          <li>
-            <a href="https://www.gov.uk/land-registry-public-data">Land Registry Public Data</a>
-          </li>
-        </ul>
-        <div class="ogl">
-          <h2 class="pull-left">
-            <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3"><img alt="OGL" src="https://assets.digital.cabinet-office.gov.uk/static/open-government-licence_2x-d273d7eca3045d3b710a863d9bfc0b33.png"></img></a>
-          </h2>
-          <p>
-            All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3">Open Government Licence v3.0</a> except where otherwise stated
-          </p>
-        </div>
-        <div class="clearfix"></div>
-      </div>
-    </footer>
-    <script type="text/javascript">
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-21165003-6']);
-  _gaq.push(['_trackPageview']);
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-  </script>
-
-  </body>
-</html>
+<div class='row'>
+  <div class='col-md-12'>
+    <h1>
+      Application error
+    </h1>
+    <p>
+      We're very sorry, but the request you just made resulted in an internal error in the application.
+      If this problem persists, please use one of the contact methods below to report the problem
+      to us, so that we can resolve it and help you get the data you require.
+    </p>
+    <h2 id="contact-us">
+      Who to contact
+    </h2>
+    <p>
+      If you are unable to access the data please <a href="http://site.landregistry.gov.uk/contact-us/form">fill in our
+        contact form</a>.
+    </p>
+    <p>
+      For general transaction data enquiries email <a href="mailto:DRO@landregistry.gov.uk">DRO@landregistry.gov.uk</a>
+    </p>
+    <p>
+      For general price paid data enquiries contact <a
+        href="mailto:data.services@mail.landregistry.gov.uk">data.services@mail.landregistry.gov.uk</a>.
+    </p>
+  </div><!--/.col-md-12-->
+</div>


### PR DESCRIPTION
This PR includes the following updates and resolves the linked issues:

- Refactors the elapsed time calculated for API requests to be resolved as microseconds rather than milliseconds. This is to improve the reporting of the elapsed time in the system tooling logs. [#104](https://github.com/epimorphics/hmlr-linked-data/issues/104)/[#111](https://github.com/epimorphics/hmlr-linked-data/issues/111)
- Minor text changes to the `Gemfile` to include instructions for running Epimorphics specific gems locally during the development of those gems.
- Updated the production `data_services_api` gem version to be at least the current version`~>1.3.2` (this is to cover out of sync release versions)
- Updated the production `lr_common_styles` gem version to be at least the current version `~>1.9.0` (this is to cover out of sync release versions)
- Refactored better guards in `entrypoint.sh` to ensure the required env vars are set accordingly or deployment will fail noisily.
- Refactored the error messages displayed to be semantically formatted as well as incorporated ALL lines for the returned message to be held in the variable instead of being possibly displayed outside of the intended context.
- Adjusted the processing of error status to use the application template; also includes adjustments to not double render the error response. [#103](https://github.com/epimorphics/hmlr-linked-data/issues/103)
- Added the updated configuration for the AWS credential improvements as per other readme's; included further info to run the application locally; resolved a markdown linting issue with using HTML in markdown.