### PR TITLE
Resolving the url root for search terms

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module PpdExplorer
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    config.assets.paths << Rails.root.join('app', 'assets', 'fonts')
+    config.assets.paths << Rails.root.join('app/assets/fonts')
   end
 end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,3 +98,9 @@ PpdExplorer::Application.configure do
   # Set the contact email address to Land Registry supplied address
   config.contact_email_address = 'data.services@mail.landregistry.gov.uk'
 end
+
+# Set the default url options for the relative url root
+# This is required for the correct path to be set when running the app in a
+# subdirectory for the application
+Rails.application.routes.default_url_options[:relative_url_root] =
+  ENV.fetch('RAILS_RELATIVE_URL_ROOT', '/app/ppd')

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,7 +4,7 @@ if ENV['SENTRY_API_KEY']
   Sentry.init do |config|
     config.dsn = ENV['SENTRY_API_KEY']
     config.environment = ENV['DEPLOYMENT_ENVIRONMENT'] || Rails.env
-    config.enabled_environments = %w[production test]
+    config.enabled_environments = %w[production]
     config.release = Version::VERSION
     config.breadcrumbs_logger = %i[active_support_logger http_logger]
     config.excluded_exceptions += ['ActionController::BadRequest']


### PR DESCRIPTION
With the updates for the infrastructure the relative url root was missing from the search term paths, this update restores the sub-directory location on the production instances to include the correct path.

### Additional changes

- linting update on method parameter format
- removal of Sentry monitoring from Test environment