### PR TITLE
Set the `change_default_caching_policy` in the app `before_action`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This app allows the user to explore HMLR price-paid open linked data.
 
+## 1.7.3.1 - 2023-07-11
+
+- (Jon) Updated the `app/controllers/application_controller.rb` to include the
+  `before_action` for the `change_default_caching_policy` method to ensure the
+  default `Cache-Control` header for all requests is set to 5 minutes (300 seconds).
+
 ## 1.7.3 - 2023-06-07
 
 - (Jon) Updated the `json_rails_logger` gem to the latest 1.0.1 patchrelease.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,8 @@ class ApplicationController < ActionController::Base
   # temporarily disable csrf for load testing. Was: protect_from_forgery with: :exception
   protect_from_forgery with: :null_session
 
-  before_action :set_phase
+  before_action :set_phase, :change_default_caching_policy
+
   def set_phase
     @phase = :released
   end

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -4,6 +4,6 @@ module Version
   MAJOR = 1
   MINOR = 7
   PATCH = 3
-  SUFFIX = nil
+  SUFFIX = 1
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end


### PR DESCRIPTION
Using `before_action`s let's us "prepare" the data necessary before the action in the controller executes. In this case setting the cache headers to the desired length.

https://github.com/epimorphics/hmlr-linked-data/issues/114
