### PR TITLE
Resolve Missing Template 404 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This app allows the user to explore HMLR price-paid open linked data.
 
 ## 1.7.6 - 2024-03-08
 
-- (Jon) Updated the application_controller to include a
+- (Jon) Updated the application_controller to include an
   `ActionView::MissingTemplate` rescue to ensure the correct 404 template is
   displayed when a template is not found
   [GH-138](https://github.com/epimorphics/hmlr-linked-data/issues/138)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This app allows the user to explore HMLR price-paid open linked data.
 
+## 1.7.6 - 2024-03-08
+
+- (Jon) Updated the application_controller to include a
+  `ActionView::MissingTemplate` rescue to ensure the correct 404 template is
+  displayed when a template is not found
+  [GH-138](https://github.com/epimorphics/hmlr-linked-data/issues/138)
+
 ## 1.7.5 - 2023-11-27
 
 - (Jon) Updated the `lr_common_styles` gem to the latest 1.9.3 patch release.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,10 +22,13 @@ class ApplicationController < ActionController::Base
     detailed_request_log(duration)
   end
 
+  # Handle specific types of exceptions and render the appropriate error page
+  # or attempt to render a generic error page if no specific error page exists
   unless Rails.application.config.consider_all_requests_local
     rescue_from ActionController::InvalidCrossOriginRequest, with: :render403
     rescue_from ActionController::RoutingError, with: :render404
     rescue_from ActionController::BadRequest, with: :render400
+    rescue_from ActionView::MissingTemplate, with: :render404
     rescue_from Exception, with: :render_exception
   end
 

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 1
   MINOR = 7
-  PATCH = 5
+  PATCH = 6
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end


### PR DESCRIPTION
Updated the application_controller to include an `ActionView::MissingTemplate` rescue to ensure the correct 404 template is displayed when a template is not found.

Closes https://github.com/epimorphics/hmlr-linked-data/issues/138

### Additional changes:

- Minor reorganisation of helper methods in application controller for readability