### PR TITLE
Resolve Missing Template error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -69,9 +69,8 @@ class ApplicationController < ActionController::Base
 
     respond_to do |format|
       format.html { render_html_error_page(status) }
-      format.all do
-        render nothing: true, status: status
-      end
+      # Anything else returns the status as human readable plain string
+      format.all { render plain: Rack::Utils::HTTP_STATUS_CODES[status].to_s, status: status }
     end
   end
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,7 +8,7 @@ class SearchController < ApplicationController
     create
   end
 
-  # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/MethodLength
   def create
     @preferences = UserPreferences.new(params)
 


### PR DESCRIPTION
This PR changes the way errors are handled and determines which manner to render an error to the user; this also removes an erroneous Rubocop rule that is no longer needed