### PR TITLE
fixes flow control on search modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This app allows the user to explore HMLR price-paid open linked data.
 
 ## 1.7.7 - 2024-08
 
+- (Dan) updates the search results modal to include focus flow [GH-216](https://github.com/epimorphics/ppd-explorer/issues/216)
 - (Dan) updates the form to meet various accessibility requirments [GH-217](https://github.com/epimorphics/ppd-explorer/issues/217)
 
 ## 1.7.6 - 2024-03-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This app allows the user to explore HMLR price-paid open linked data.
 
 ## 1.7.7 - 2024-08
 
-- (Dan) updates the search results modal to include focus flow [GH-216](https://github.com/epimorphics/ppd-explorer/issues/216)
+- (Dan) updates the search results modal focus flow to meet accessibility requirments [GH-216](https://github.com/epimorphics/ppd-explorer/issues/216)
 - (Dan) updates the form to meet various accessibility requirments [GH-217](https://github.com/epimorphics/ppd-explorer/issues/217)
 
 ## 1.7.6 - 2024-03-08

--- a/app/assets/javascripts/bookmark-modal.js
+++ b/app/assets/javascripts/bookmark-modal.js
@@ -8,7 +8,7 @@ document.addEventListener("DOMContentLoaded",  function () {
 
   function onModalOpen() {
     document.addEventListener('keydown', function(e) {
-        var isTabPressed = e.key === 'Tab' || e.keyCode === 9;
+        var isTabPressed = e.key === 'Tab';
       
         if (!isTabPressed) {
           return;

--- a/app/assets/javascripts/bookmark-modal.js
+++ b/app/assets/javascripts/bookmark-modal.js
@@ -1,0 +1,37 @@
+document.addEventListener("DOMContentLoaded",  function () {
+  const focusableElements = 'input, .btn, .close'
+  const modal = document.querySelector('#bookmark-dialog');
+  const firstFocusableElement = modal.querySelectorAll(focusableElements)[0];
+  const focusableContent = modal.querySelectorAll(focusableElements);
+  const lastFocusableElement = focusableContent[focusableContent.length - 1];
+  const shareViewButton = document.querySelector(".action-bookmark")
+
+  function onModalOpen() {
+    document.addEventListener('keydown', function(e) {
+        let isTabPressed = e.key === 'Tab' || e.keyCode === 9;
+      
+        if (!isTabPressed) {
+          return;
+        }
+      
+        if (e.shiftKey) { 
+          if (document.activeElement === firstFocusableElement) {
+            lastFocusableElement.focus();
+            e.preventDefault();
+          }
+        } else { 
+          if (document.activeElement === lastFocusableElement) { 
+            firstFocusableElement.focus(); 
+            e.preventDefault();
+          }
+        }
+      });
+      
+      firstFocusableElement.focus();
+  }
+
+  shareViewButton.addEventListener("click", function (event) {
+    event.preventDefault()
+    onModalOpen()
+  })
+})

--- a/app/assets/javascripts/bookmark-modal.js
+++ b/app/assets/javascripts/bookmark-modal.js
@@ -8,7 +8,7 @@ document.addEventListener("DOMContentLoaded",  function () {
 
   function onModalOpen() {
     document.addEventListener('keydown', function(e) {
-        let isTabPressed = e.key === 'Tab' || e.keyCode === 9;
+        var isTabPressed = e.key === 'Tab' || e.keyCode === 9;
       
         if (!isTabPressed) {
           return;

--- a/app/assets/javascripts/bookmark-modal.js
+++ b/app/assets/javascripts/bookmark-modal.js
@@ -1,10 +1,10 @@
 document.addEventListener("DOMContentLoaded",  function () {
-  const focusableElements = 'input, .btn, .close'
-  const modal = document.querySelector('#bookmark-dialog');
-  const firstFocusableElement = modal.querySelectorAll(focusableElements)[0];
-  const focusableContent = modal.querySelectorAll(focusableElements);
-  const lastFocusableElement = focusableContent[focusableContent.length - 1];
-  const shareViewButton = document.querySelector(".action-bookmark")
+  var focusableElements = 'input, .btn, .close'
+  var modal = document.querySelector('#bookmark-dialog');
+  var firstFocusableElement = modal.querySelectorAll(focusableElements)[0];
+  var focusableContent = modal.querySelectorAll(focusableElements);
+  var lastFocusableElement = focusableContent[focusableContent.length - 1];
+  var shareViewButton = document.querySelector(".action-bookmark")
 
   function onModalOpen() {
     document.addEventListener('keydown', function(e) {

--- a/app/assets/javascripts/bookmark-modal.js
+++ b/app/assets/javascripts/bookmark-modal.js
@@ -4,7 +4,7 @@ document.addEventListener("DOMContentLoaded",  function () {
   var firstFocusableElement = modal.querySelectorAll(focusableElements)[0];
   var focusableContent = modal.querySelectorAll(focusableElements);
   var lastFocusableElement = focusableContent[focusableContent.length - 1];
-  var shareViewButton = document.querySelector(".action-bookmark")
+  var shareViewButton = document.querySelectorAll(".action-bookmark")
 
   function onModalOpen() {
     document.addEventListener('keydown', function(e) {
@@ -30,8 +30,10 @@ document.addEventListener("DOMContentLoaded",  function () {
       firstFocusableElement.focus();
   }
 
-  shareViewButton.addEventListener("click", function (event) {
-    event.preventDefault()
-    onModalOpen()
-  })
+  shareViewButton.forEach(button => {
+    button.addEventListener("click", function (event) {
+      event.preventDefault();
+      onModalOpen();
+    });
+  });
 })

--- a/app/views/ppd/_bookmark_modal.html.haml
+++ b/app/views/ppd/_bookmark_modal.html.haml
@@ -1,11 +1,12 @@
 -# frozen_string_literal: true
 
 #bookmark-modal.modal
-  .modal-dialog
+  #bookmark-dialog.modal-dialog{role: "dialog", "aria-labelledby": "bookmark-link", "aria-modal": "true"}
     .modal-content
       .modal-header
         %button.close{ type: "button", data: {dismiss: "modal"}, aria: {hidden: "true"}}
           &times;
+        #bookmark-link 
         %h2.modal-title
           Link to the current search
       .modal-body

--- a/app/views/ppd/_bookmark_modal.html.haml
+++ b/app/views/ppd/_bookmark_modal.html.haml
@@ -22,10 +22,6 @@
           .twitter
             %a.twitter-share-button{ href: "https://twitter.com/share", data: {url: "", text: "Open data from Land Registry", hashtags: "opendata"}}
               Tweet
-          .gplus
-            #plus-one
-          .facebook
-            .fb-share-button{ data: {href: "", type: "button_count"}}
 
       .modal-footer
         .row


### PR DESCRIPTION
I removed unused and broken code that added an Iframe to the Modal causing a focus flow issue.
Gplus is no longer a social service
Facebook code contained no href

Neither of the above services were visible to the user so I assume they are unrequired.

The control flow is now fixed according to manual testing and Silktide please see the screenshot. Focus on the numbers 28 29 30. 

I have also added a focus flow trap to the modal using JS so that the user explicitly has to close the modal before they can tab any other page elements.

Please also see this [slack](https://epimorphics.slack.com/archives/C0AG3EY2Y/p1723044507224739?thread_ts=1723038712.476949&cid=C0AG3EY2Y) message for clarity on the issue 

Please see this ticket https://github.com/epimorphics/ppd-explorer/issues/216

![Screenshot from 2024-08-08 08-59-04](https://github.com/user-attachments/assets/9024fcab-5b7f-4d76-97d9-53ae258bd503)


 