### PR TITLE
Increases target size of clickable to meet accessibility standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This app allows the user to explore HMLR price-paid open linked data.
 
 ## 1.7.7 - 2024-08
 
+- (Dan) Increases target size of clickable elements to meet accessibility requirments [GH](https://github.com/epimorphics/ppd-explorer/issues/225)
 - (Dan) updates the form to meet various accessibility requirments [GH-217](https://github.com/epimorphics/ppd-explorer/issues/217)
 
 ## 1.7.6 - 2024-03-08

--- a/app/assets/stylesheets/ppd.scss
+++ b/app/assets/stylesheets/ppd.scss
@@ -69,6 +69,10 @@
       border: 1px solid #d8d8d8;
       border-radius: 4px;
     }
+
+    i {
+      padding: 4px;
+    }
   }
 
   .search-selection > span {
@@ -89,7 +93,7 @@
     }
 
     .search-zoom-button {
-      margin: 1px 3px;
+      padding: 4px 4.75px;
     }
   }
 
@@ -156,6 +160,10 @@
     padding: 8px;
     border: 1px solid #888;
     border-radius: 5px;
+  }
+
+  .transaction-url a i {
+    padding: 4px;
   }
 
   .transaction-category {


### PR DESCRIPTION
Increases the size of the following targets to a min of 24px:

- ### Remove search term 

![Screenshot from 2024-08-09 10-45-48](https://github.com/user-attachments/assets/24d83590-2318-43b4-ae9b-0dc65b8d02ee)

- ### External link 

![Screenshot from 2024-08-09 11-09-00](https://github.com/user-attachments/assets/132b520b-24a7-40a7-a811-e3e0de1dde1e)

- ### Search zoom

![Screenshot from 2024-08-09 11-54-53](https://github.com/user-attachments/assets/029411df-7b0f-4383-8e95-37e22ac5d41a)


