### PR TITLE
Primarily Prometheus Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,21 +4,51 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
-!/log/.keep
-.byebug_history
-.github-token
-.tags
+# Ignore vscode config
+.vscode
+
+## Ignore bundler configuration:
 /.bundle
-/db/*.sqlite3
-/db/*.sqlite3-journal
-/log/*.log
-/tmp
+/vendor/bundle
+/lib/bundler/man/
+
+# Ignore all logfiles and tempfiles.
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# Ignore Byebug command history file.
+.byebug_history
+
+# Ignore node_modules
+node_modules/
+
+# Ignore precompiled javascript packs
 /public/packs
 /public/packs-test
-/public/assets/
-coverage/
+/public/assets
+
+# Ignore uploaded files in development
+/storage/*
+!/storage/.keep
+/public/uploads
+
+### Rails specific ###
+.byebug_history
+/public/system
+/coverage/
+tmp
+
+# Ignore files specific to the development environment
 fc.json
 fc_simple.json
 index-names.txt
 index.json
 tags
+
+# Ignore dot files used by environment or IDE tools
+.tags
+.tool-versions
+.github-token
+.npmrc

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,7 @@ Layout/LineLength:
     - test/**/*
 
 Metrics/ClassLength:
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
   Exclude:
     - test/**/*
 
@@ -24,7 +25,9 @@ Metrics/BlockLength:
     - lib/tasks/**/*
 
 Metrics/MethodLength:
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
   Exclude:
+    - test/**/*
     - lib/tasks/location.rake
 
 Style/FormatStringToken:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,10 +13,18 @@ Layout/LineLength:
     - config/**/*
     - test/**/*
 
-Metrics/ClassLength:
-  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
+Lint/ConstantDefinitionInBlock:
   Exclude:
     - test/**/*
+
+Lint/DuplicateBranch:
+  Enabled: false
+
+Metrics/AbcSize:
+  Max: 30
+  Exclude:
+    - test/**/*
+    - lib/tasks/**/*
 
 Metrics/BlockLength:
   Max: 30
@@ -24,25 +32,23 @@ Metrics/BlockLength:
     - test/**/*
     - lib/tasks/**/*
 
+Metrics/ClassLength:
+  CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
+  Exclude:
+    - test/**/*
+
 Metrics/MethodLength:
   CountAsOne: ['array', 'hash', 'heredoc', 'method_call']
   Exclude:
     - test/**/*
     - lib/tasks/location.rake
 
-Style/FormatStringToken:
-  Enabled: false
-
 Style/Documentation:
   Exclude:
     - test/**/*
 
-Style/OptionalBooleanParameter:
+Style/FormatStringToken:
   Enabled: false
 
-Lint/ConstantDefinitionInBlock:
-  Exclude:
-    - test/**/*
-
-Lint/DuplicateBranch:
+Style/OptionalBooleanParameter:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,41 @@
 
 This app allows the user to explore HMLR price-paid open linked data.
 
+## 1.7.8 - 2024-08
+
+- (Jon) Implemented improved boilerplate metrics integration to offer analysis
+  of current application usage stats
+- (Jon) Additional metrics from the Puma server to be exposed in the /metrics
+  endpoint via the puma-metrics gem
+- (Jon) Tweaked the application controller to improve error handling and
+  ensuring additional filtering for specific errors completes when able
+- (Jon) Reorganised makefile targets alphabetically as well as mirrored other
+  improvements from the other applications in the suite
+- (Jon) Updated .gitignore file to mirror the current approach in the other HMLR
+  apps
+- (Jon) Updated .rubocop.yml file with rules to reduce the need to set overrides
+  inline
+- (Jon) Updated the `lr_common_styles` gem to the latest 1.9.6 patch release.
+
 ## 1.7.7 - 2024-08
 
-- (Dan) Fixes the bug search results not displaying [232](https://github.com/epimorphics/ppd-explorer/issues/232)
-- (Dan) Adds page titles to donwload page and error page. Improves code dryness [220](https://github.com/epimorphics/ppd-explorer/issues/220)
+- (Dan) Fixes the bug search results not displaying
+  [232](https://github.com/epimorphics/ppd-explorer/issues/232)
+- (Dan) Adds page titles to donwload page and error page. Improves code dryness
+  [220](https://github.com/epimorphics/ppd-explorer/issues/220)
 - (Dan) Updates gemfile to use v1.9.5 lr_common_styles
-- (Dan) Adds more descriptive page titles [220](https://github.com/epimorphics/ppd-explorer/issues/220)
-- (Dan) Adds search actions buttons to the top of the page [226](https://github.com/epimorphics/ppd-explorer/issues/226)
-- (Dan) Increases target size of clickable elements to meet accessibility requirments [GH-225](https://github.com/epimorphics/ppd-explorer/issues/225)
-- (Dan) updates the search results modal focus flow to meet accessibility requirments [GH-216](https://github.com/epimorphics/ppd-explorer/issues/216)
-- (Dan) updates the form to meet various accessibility requirments [GH-217](https://github.com/epimorphics/ppd-explorer/issues/217)
-- (Dan) updates the help modal focus flow to meet accessibility requirments [GH-218](https://github.com/epimorphics/ppd-explorer/issues/218)
+- (Dan) Adds more descriptive page titles
+  [220](https://github.com/epimorphics/ppd-explorer/issues/220)
+- (Dan) Adds search actions buttons to the top of the page
+  [226](https://github.com/epimorphics/ppd-explorer/issues/226)
+- (Dan) Increases target size of clickable elements to meet accessibility
+  requirments [GH-225](https://github.com/epimorphics/ppd-explorer/issues/225)
+- (Dan) updates the search results modal focus flow to meet accessibility
+  requirments [GH-216](https://github.com/epimorphics/ppd-explorer/issues/216)
+- (Dan) updates the form to meet various accessibility requirments
+  [GH-217](https://github.com/epimorphics/ppd-explorer/issues/217)
+- (Dan) updates the help modal focus flow to meet accessibility requirments
+  [GH-218](https://github.com/epimorphics/ppd-explorer/issues/218)
 
 ## 1.7.6 - 2024-03-08
 
@@ -35,7 +59,8 @@ This app allows the user to explore HMLR price-paid open linked data.
 
 - (Jon) Updated the `app/controllers/application_controller.rb` to include the
   `before_action` for the `change_default_caching_policy` method to ensure the
-  default `Cache-Control` header for all requests is set to 5 minutes (300 seconds).
+  default `Cache-Control` header for all requests is set to 5 minutes (300
+  seconds).
 
 ## 1.7.3 - 2023-06-07
 
@@ -62,8 +87,8 @@ This app allows the user to explore HMLR price-paid open linked data.
   Epimorphics specific gems locally during the development of those gems.
 - (Jon) Updated the production `data_services_api` gem version to be at least
   the current version`~>1.3.3` (this is to cover out of sync release versions)
-- (Jon) Updated the production `json_rails_logger` gem version to be at least the
-  current version `~>1.3.5` (this is to cover out of sync release versions)
+- (Jon) Updated the production `json_rails_logger` gem version to be at least
+  the current version `~>1.3.5` (this is to cover out of sync release versions)
 - (Jon) Updated the production `lr_common_styles` gem version to be at least the
   current version `~>1.9.1` (this is to cover out of sync release versions)
 - (Jon) Refactored better guards in `entrypoint.sh` to ensure the required env

--- a/Gemfile
+++ b/Gemfile
@@ -87,5 +87,5 @@ gem 'puma-metrics'
 source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'data_services_api', '~> 1.3.3'
   gem 'json_rails_logger', '~>1.0.0'
-  gem 'lr_common_styles', '~> 1.9', '>=1.9.6'
+  gem 'lr_common_styles', '~> 1.9', '>= 1.9.6'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -84,5 +84,5 @@ gem 'yajl-ruby', require: 'yajl'
 source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'data_services_api', '~> 1.3.3'
   gem 'json_rails_logger', '~>1.0.0'
-  gem 'lr_common_styles', '~> 1.9', '>= 1.9.5'
+  gem 'lr_common_styles', '~> 1.9', '>= 1.9.6'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -87,5 +87,5 @@ gem 'puma-metrics'
 source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'data_services_api', '~> 1.3.3'
   gem 'json_rails_logger', '~>1.0.0'
-  gem 'lr_common_styles', '~> 1.9', '>= 1.9.6'
+  gem 'lr_common_styles', '~> 1.9.6' # set as this version as bundler breaks otherwise
 end

--- a/Gemfile
+++ b/Gemfile
@@ -72,12 +72,15 @@ gem 'prometheus-client', '~> 4.0'
 gem 'sentry-rails', '~> 5.2'
 gem 'yajl-ruby', require: 'yajl'
 
+gem 'puma-metrics'
+
+
 # rubocop:disable Layout/LineLength
 # TODO: While running the rails app locally for testing you can set gems to your local path
 # ! These "local" paths do not work with a docker image - use the repo instead
 # gem 'data_services_api', '~> 1.3.3', path: '~/Epimorphics/shared/data_services_api/'
 # gem 'json_rails_logger', '~>1.0.0', path: '~/Epimorphics/shared/json-rails-logger/'
-# gem 'lr_common_styles', '~> 1.9.3', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles/'
+# gem 'lr_common_styles', '~> 1.9', '>= 1.9.6', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles/'
 # rubocop:enable Layout/LineLength
 
 # TODO: In production you want to set this to the gem from the epimorphics package repo

--- a/Gemfile
+++ b/Gemfile
@@ -87,5 +87,5 @@ gem 'puma-metrics'
 source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'data_services_api', '~> 1.3.3'
   gem 'json_rails_logger', '~>1.0.0'
-  gem 'lr_common_styles', '~> 1.9', '>= 1.9.6'
+  gem 'lr_common_styles', '~> 1.9.6'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -87,5 +87,5 @@ gem 'puma-metrics'
 source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'data_services_api', '~> 1.3.3'
   gem 'json_rails_logger', '~>1.0.0'
-  gem 'lr_common_styles', '~> 1.9.6'
+  gem 'lr_common_styles', '~> 1.9', '>=1.9.6'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,9 @@ GEM
     public_suffix (5.0.0)
     puma (5.6.7)
       nio4r (~> 2.0)
+    puma-metrics (1.2.5)
+      prometheus-client (>= 0.10)
+      puma (>= 5.0)
     racc (1.6.2)
     rack (2.2.8)
     rack-test (1.1.0)
@@ -395,6 +398,7 @@ DEPENDENCIES
   mocha
   prometheus-client (~> 4.0)
   puma
+  puma-metrics
   rails (< 6.0.0)
   rb-readline
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,19 @@ GEM
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    lr_common_styles (1.9.6)
+      bootstrap-sass (~> 3.4.0)
+      font-awesome-rails (~> 4.7.0.1)
+      govuk_elements_rails (~> 2.0.0)
+      govuk_frontend_toolkit (~> 4.18.1)
+      govuk_template (~> 0.18.1)
+      haml-rails (~> 2.0.0)
+      jquery-rails (~> 4.3.5)
+      lodash-rails (~> 4.17.14)
+      modernizr-rails (~> 2.7.1)
+      modulejs-rails (~> 2.2.0.0)
+      rails (~> 5.2.4)
+      sass-rails (~> 5.0.4)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
@@ -345,19 +358,6 @@ GEM
       json
       lograge
       railties
-    lr_common_styles (1.9.5)
-      bootstrap-sass (~> 3.4.0)
-      font-awesome-rails (~> 4.7.0.1)
-      govuk_elements_rails (~> 2.0.0)
-      govuk_frontend_toolkit (~> 4.18.1)
-      govuk_template (~> 0.18.1)
-      haml-rails (~> 2.0.0)
-      jquery-rails (~> 4.3.5)
-      lodash-rails (~> 4.17.14)
-      modernizr-rails (~> 2.7.1)
-      modulejs-rails (~> 2.2.0.0)
-      rails (~> 5.2.4)
-      sass-rails (~> 5.0.4)
 
 PLATFORMS
   -darwin-20
@@ -386,7 +386,7 @@ DEPENDENCIES
   json_expressions
   json_rails_logger (~> 1.0.0)!
   libv8-node (>= 16.10.0.0)
-  lr_common_styles (~> 1.9, >= 1.9.5)!
+  lr_common_styles (~> 1.9, >= 1.9.6)!
   memory_profiler
   minitest-rails
   minitest-reporters

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ BUNDLER_VERSION?=$(shell tail -1 Gemfile.lock | tr -d ' ')
 ECR?=${ACCOUNT}.dkr.ecr.eu-west-1.amazonaws.com
 GPR_OWNER?=epimorphics
 NAME?=$(shell awk -F: '$$1=="name" {print $$2}' deployment.yaml | sed -e 's/[[:blank:]]//g')
-SHORTNAME?=$(shell echo ${NAME} | cut -f2 -d/)
 PAT?=$(shell read -p 'Github access token:' TOKEN; echo $$TOKEN)
 PORT?=3001
 RUBY_VERSION?=$(shell cat .ruby-version)
@@ -29,13 +28,13 @@ REPO?=${ECR}/${IMAGE}
 GITHUB_TOKEN=.github-token
 BUNDLE_CFG=.bundle/config
 
-all: image
-
 ${BUNDLE_CFG}: ${GITHUB_TOKEN}
 	@./bin/bundle config set --local rubygems.pkg.github.com ${GPR_OWNER}:`cat ${GITHUB_TOKEN}`
 
 ${GITHUB_TOKEN}:
 	@echo ${PAT} > ${GITHUB_TOKEN}
+
+all: image
 
 assets: auth
 	@./bin/bundle config set --local without 'development test'
@@ -49,6 +48,7 @@ check: lint test
 
 clean:
 	@[ -d public/assets ] && ./bin/rails assets:clobber || :
+	@@ rm -rf bundle coverage log node_modules
 
 image: auth
 	@echo Building ${REPO}:${TAG} ...
@@ -112,7 +112,6 @@ vars:
 	@echo "ECR = ${ECR}"
 	@echo "GPR_OWNER = ${GPR_OWNER}"
 	@echo "NAME = ${NAME}"
-	@echo "SHORTNAME = ${SHORTNAME}"
 	@echo "RUBY_VERSION = ${RUBY_VERSION}"
 	@echo "SHORTNAME = ${SHORTNAME}"
 	@echo "STAGE = ${STAGE}"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,7 +84,7 @@ class ApplicationController < ActionController::Base
     self.response_body = nil
   end
 
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def detailed_request_log(duration)
     env = request.env
 
@@ -112,7 +112,7 @@ class ApplicationController < ActionController::Base
       Rails.logger.info(JSON.generate(log_fields))
     end
   end
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def instrument_internal_error(exception)
     ActiveSupport::Notifications.instrument('internal_error.application', exception: exception)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,7 +84,7 @@ class ApplicationController < ActionController::Base
     self.response_body = nil
   end
 
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize
   def detailed_request_log(duration)
     env = request.env
 
@@ -112,7 +112,7 @@ class ApplicationController < ActionController::Base
       Rails.logger.info(JSON.generate(log_fields))
     end
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize
 
   def instrument_internal_error(exception)
     ActiveSupport::Notifications.instrument('internal_error.application', exception: exception)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,10 +5,12 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
 
-  # temporarily disable csrf for load testing. Was: protect_from_forgery with: :exception
+  # Temporarily disable csrf for load testing.
+  # Was: protect_from_forgery with: :exception
   protect_from_forgery with: :null_session
 
-  before_action :set_phase, :change_default_caching_policy
+  before_action :set_phase
+  before_action :change_default_caching_policy
   around_action :log_request_result
 
   def set_phase
@@ -114,6 +116,11 @@ class ApplicationController < ActionController::Base
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
+  # Notify subscriber(s) of an internal error event with the payload of the
+  # exception once done
+  # @param [Exception] exp the exception that caused the error
+  # @return [ActiveSupport::Notifications::Event] provides an object-oriented
+  # interface to the event
   def instrument_internal_error(exception)
     ActiveSupport::Notifications.instrument('internal_error.application', exception: exception)
   end

--- a/app/controllers/concerns/dsapi_turtle_formatter.rb
+++ b/app/controllers/concerns/dsapi_turtle_formatter.rb
@@ -34,7 +34,6 @@ module DsapiTurtleFormatter
     ttl_value
   end
 
-  # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
   def format_ttl_value(value)
     f =
@@ -60,6 +59,5 @@ module DsapiTurtleFormatter
 
     f.html_safe
   end
-  # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 end

--- a/app/controllers/concerns/dsapi_turtle_formatter.rb
+++ b/app/controllers/concerns/dsapi_turtle_formatter.rb
@@ -17,7 +17,7 @@ module DsapiTurtleFormatter
     results.map { |r| result_to_ttl(r) }
   end
 
-  def result_to_ttl(result) # rubocop:disable Metrics/MethodLength
+  def result_to_ttl(result)
     ttl_value = { properties: [] }
 
     result.map do |property, value|
@@ -34,7 +34,7 @@ module DsapiTurtleFormatter
     ttl_value
   end
 
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
   def format_ttl_value(value)
     f =
@@ -60,6 +60,6 @@ module DsapiTurtleFormatter
 
     f.html_safe
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -8,7 +8,6 @@ class SearchController < ApplicationController
     create
   end
 
-  # rubocop:disable Metrics/MethodLength
   def create
     @preferences = UserPreferences.new(params)
 
@@ -36,7 +35,6 @@ class SearchController < ApplicationController
 
     render_error_page(e, e.message, status)
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/PerceivedComplexity
 
   def use_compact_json?
     non_compact_formats.exclude?(request.format)
@@ -48,7 +46,7 @@ class SearchController < ApplicationController
 
   private
 
-  # rubocop:disable Layout/LineLength, Metrics/MethodLength
+  # rubocop:disable Layout/LineLength
   def render_error_page(err, message, status, template = 'ppd/error')
     # link the error to the actual request id otherwise generate one for this error
     uuid = Thread.current[:request_id] || SecureRandom.uuid
@@ -69,5 +67,5 @@ class SearchController < ApplicationController
       ].join.html_safe
     render(template: template, status: status)
   end
-  # rubocop:enable Layout/LineLength, Metrics/MethodLength
+  # rubocop:enable Layout/LineLength
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -46,7 +46,7 @@ class SearchController < ApplicationController
 
   private
 
-  # rubocop:disable Layout/LineLength
+  # rubocop:disable Layout/LineLength, Metrics/MethodLength
   def render_error_page(err, message, status, template = 'ppd/error')
     # link the error to the actual request id otherwise generate one for this error
     uuid = Thread.current[:request_id] || SecureRandom.uuid
@@ -64,8 +64,8 @@ class SearchController < ApplicationController
         '<p>Include the following information to support staff so that they can investigate this specific incident.</p>',
         "<p class='error bg-warning'>#{@message}.</p>",
         "<p>The trace reference for this error is<span class='sr-only px-1'> Code</span>: <code>#{uuid}</code></p>"
-      ].join.html_safe
+      ].join.html_safe # rubocop:disable Rails/OutputSafety
     render(template: template, status: status)
   end
-  # rubocop:enable Layout/LineLength
+  # rubocop:enable Layout/LineLength, Metrics/MethodLength
 end

--- a/app/helpers/ppd_helper.rb
+++ b/app/helpers/ppd_helper.rb
@@ -10,7 +10,7 @@ module PpdHelper
     end
   end
 
-  def address_detail_filter(aspect, result, preferences) # rubocop:disable Metrics/MethodLength
+  def address_detail_filter(aspect, result, preferences)
     vp = result.presentation_value_of_property(aspect.aspect_key_property)
     val = result.value_of_property(aspect.aspect_key_property)
 
@@ -31,7 +31,7 @@ module PpdHelper
     end
   end
 
-  def results_selection(limit, preferences) # rubocop:disable Metrics/MethodLength
+  def results_selection(limit, preferences)
     if preferences.selected_limit == limit
       content_tag('strong') do
         results_selection_summary(limit)

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -3,7 +3,7 @@
 module Version
   MAJOR = 1
   MINOR = 7
-  PATCH = 7
+  PATCH = 8
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/app/models/concerns/turtle_formatter.rb
+++ b/app/models/concerns/turtle_formatter.rb
@@ -7,7 +7,7 @@ module TurtleFormatter
     props.reject { |pv| ignore_pattern && pv[:p] =~ ignore_pattern }.each(&block)
   end
 
-  def result_to_ttl(result) # rubocop:disable Metrics/MethodLength
+  def result_to_ttl(result)
     ttl_value = { properties: [] }
 
     result.map do |property, value|
@@ -24,7 +24,7 @@ module TurtleFormatter
     ttl_value
   end
 
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
   def format_ttl_value(value)
     f =
@@ -54,6 +54,6 @@ module TurtleFormatter
 
     f.html_safe
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
 end

--- a/app/models/paon.rb
+++ b/app/models/paon.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # LR PAONs, which are strings with a custom sort order
-class Paon < String # rubocop:disable Metrics/ClassLength
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+class Paon < String
+  # rubocop:disable Metrics/AbcSize
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def <=>(other)
     pe0 = elements(self)
@@ -51,7 +51,7 @@ class Paon < String # rubocop:disable Metrics/ClassLength
       0
     end
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   def self.to_paon(value)

--- a/app/models/query_command.rb
+++ b/app/models/query_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Command object providing a service for driving the DsAPI
-class QueryCommand < DataService # rubocop:disable Metrics/ClassLength
+class QueryCommand < DataService
   include TurtleFormatter
 
   attr_reader :all_results, :search_results, :error_message

--- a/app/models/search_aspect.rb
+++ b/app/models/search_aspect.rb
@@ -34,7 +34,7 @@ class SearchAspect < Aspect
   end
 
   # Sanitise input and convert to Lucene expression
-  def text_index_term(preferences) # rubocop:disable Metrics/MethodLength
+  def text_index_term(preferences)
     terms = sanitise_punctuation(preference_value(preferences))
             .split
             .reject { |token| LUCENE_KEYWORDS.include?(token.downcase) }

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # An individual result returned from the search service
-class SearchResult # rubocop:disable Metrics/ClassLength
+class SearchResult
   attr_reader :result
 
   PPD = 'http://landregistry.data.gov.uk/def/ppi/'

--- a/app/subscribers/action_controller_prometheus_subscriber.rb
+++ b/app/subscribers/action_controller_prometheus_subscriber.rb
@@ -7,11 +7,21 @@
 class ActionControllerPrometheusSubscriber < ActiveSupport::Subscriber
   attach_to :action_controller
 
+  # rubocop:disable Metric/AbcSize
   def process_action(_event)
     mem = GetProcessMem.new
 
     Prometheus::Client.registry
                       .get(:memory_used_mb)
                       .set(mem.mb)
+
+    Prometheus::Client.registry
+                      .get(:thread_count)
+                      .set(Thread.list.select { |thread| %w[run sleep].include?(thread.status) }.count)
+
+    Prometheus::Client.registry
+                      .get(:process_threads)
+                      .set(Thread.list.select { |thread| thread.status == 'run' }.count)
   end
+  # rubocop:enable Metric/AbcSize
 end

--- a/app/subscribers/api_prometheus_subscriber.rb
+++ b/app/subscribers/api_prometheus_subscriber.rb
@@ -4,7 +4,7 @@
 class ApiPrometheusSubscriber < ActiveSupport::Subscriber
   attach_to :api
 
-  def response(event) # rubocop:disable Metrics/MethodLength
+  def response(event)
     response = event.payload[:response]
     duration = event.payload[:duration]
 

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -3,4 +3,4 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV.fetch('BUNDLE_GEMFILE', nil))

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,7 +89,7 @@ PpdExplorer::Application.configure do
   # API_SERVICE_URL should also be specified in the entrypoint.sh file and
   # set in the Makefile as an env variable for the docker container when run as an image.
   # API_SERVICE_URL is required by both Docker image and Rails
-  config.api_service_url = ENV['API_SERVICE_URL']
+  config.api_service_url = ENV.fetch('API_SERVICE_URL', nil)
 
   # Use default paths for documentation.
   config.accessibility_document_path = '/accessibility'

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -5,27 +5,27 @@ prometheus = Prometheus::Client.registry
 # Prometheus counters
 prometheus.counter(
   :api_status,
-  docstring: 'Response from back-end API',
+  docstring: 'Response from back-end API, labelled by status',
   labels: [:status]
 )
 prometheus.counter(
   :api_requests,
-  docstring: 'Overall count of back-end API requests',
+  docstring: 'Overall count of back-end API requests, labelled by result',
   labels: [:result]
 )
 prometheus.counter(
   :api_connection_failure,
-  docstring: 'Reasons for back-end API connection failure',
+  docstring: 'Reasons for back-end API connection failure, labelled by message',
   labels: [:message]
 )
 prometheus.counter(
   :api_service_exception,
-  docstring: 'The response from the back-end data API was not processed',
+  docstring: 'The response from the back-end data API was not processed, labelled by message',
   labels: [:message]
 )
 prometheus.counter(
   :internal_application_error,
-  docstring: 'Unexpected events and internal error count',
+  docstring: 'Unexpected events and internal error count, labelled by message',
   labels: [:message]
 )
 
@@ -36,13 +36,10 @@ prometheus.gauge(
 )
 
 prometheus.gauge(
-  :thread_count,
-  docstring: 'The number of threads currently alive'
-)
-
-prometheus.gauge(
   :process_threads,
-  docstring: 'The number of currently running threads'
+  docstring: 'The number of process threads, labelled by status',
+  labels: [:status],
+  preset_labels: { status: 'total' }
 )
 
 # Prometheus histograms

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,42 +1,42 @@
 # frozen_string_literal: true
 
-registry = Prometheus::Client.registry
+prometheus = Prometheus::Client.registry
 
 # Prometheus counters
-registry.counter(
+prometheus.counter(
   :api_status,
   docstring: 'Response from back-end API',
   labels: [:status]
 )
-registry.counter(
+prometheus.counter(
   :api_requests,
   docstring: 'Overall count of back-end API requests',
   labels: [:result]
 )
-registry.counter(
+prometheus.counter(
   :api_connection_failure,
   docstring: 'Reasons for back-end API connection failure',
   labels: [:message]
 )
-registry.counter(
+prometheus.counter(
   :api_service_exception,
   docstring: 'The response from the back-end data API was not processed',
   labels: [:message]
 )
-registry.counter(
+prometheus.counter(
   :internal_application_error,
   docstring: 'Unexpected events and internal error count',
   labels: [:message]
 )
 
 # Prometheus gauges
-registry.gauge(
+prometheus.gauge(
   :memory_used_mb,
   docstring: 'Process memory usage in mb'
 )
 
 # Prometheus histograms
-registry.histogram(
+prometheus.histogram(
   :api_response_times,
   docstring: 'Histogram of response times for API requests',
   buckets: Prometheus::Client::Histogram.exponential_buckets(start: 0.005, count: 16)

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -35,6 +35,16 @@ prometheus.gauge(
   docstring: 'Process memory usage in mb'
 )
 
+prometheus.gauge(
+  :thread_count,
+  docstring: 'The number of threads currently alive'
+)
+
+prometheus.gauge(
+  :process_threads,
+  docstring: 'The number of currently running threads'
+)
+
 # Prometheus histograms
 prometheus.histogram(
   :api_response_times,

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,7 +3,7 @@
 if ENV['SENTRY_API_KEY']
   Sentry.init do |config|
     config.dsn = ENV['SENTRY_API_KEY']
-    config.environment = ENV['DEPLOYMENT_ENVIRONMENT'] || Rails.env
+    config.environment = ENV.fetch('DEPLOYMENT_ENVIRONMENT') { Rails.env }
     config.enabled_environments = %w[production]
     config.release = Version::VERSION
     config.breadcrumbs_logger = %i[active_support_logger http_logger]

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -36,6 +36,9 @@ pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 #
 # preload_app!
 
+# Additional metrics from the Puma server to be exposed in the /metrics endpoint
+plugin 'metrics'
+
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -82,7 +82,7 @@ Capybara.register_driver :rack_test do |app|
 end
 
 # To see the Chrome window while tests are running, set this var to true
-see_visible_window_while_test_run = ENV['TEST_BROWSER_VISIBLE']
+see_visible_window_while_test_run = ENV.fetch('TEST_BROWSER_VISIBLE', nil)
 
 # Set Capybara to use Chrome via Selenium
 driver = see_visible_window_while_test_run ? :chrome : :headless_chrome


### PR DESCRIPTION
Focussing primarily on ticket [#148](https://github.com/epimorphics/hmlr-linked-data/issues/148) for the addition of Prometheus metrics endpoint to the PPD Explorer, additional changes for accessibility, useability, and functionality have been interspersed.

- Implemented improved boilerplate metrics integration to offer analysis of current application usage stats
- Additional metrics from the Puma server to be exposed in the /metrics endpoint via the `puma-metrics` gem
- Tweaked the application controller to improve error handling and ensuring additional filtering for specific errors completes when able 
- Reorganised makefile targets alphabetically as well as mirrored other improvements from the other applications in the suite
- Updated .gitignore file to mirror the current approach in the other HMLR apps
- Updated .rubocop.yml file with rules to reduce the need to set overrides inline