### PR TITLE
Task: Updated CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,20 @@ This app allows the user to explore HMLR price-paid open linked data.
 
 ## Changelog
 
-## 1.7.9 - 2024-09
+## Unreleased
 
+- (Jon) Updated the application exceptions controller to instrument the
+  `ActiveSupport::Notifications` for internal errors
+  [GH-244](https://github.com/epimorphics/ppd-explorer/issues/244)
+- (Jon) Updated `config/initializers/prometheus.rb` to include the `Middleware
+  instrumentation` fix for the 0 memory bug by notifying Action Dispatch
+  subscribers on Prometheus initialise
+  [GH-244](https://github.com/epimorphics/ppd-explorer/issues/244)
+- (Jon) Updated `config/puma.rb` to include metrics plugin and port information
+  for the metrics endpoint as environment variable, with default, to enable
+  running multiple sibling HMLR apps locally if needed without port conflicts
+  [GH-244](https://github.com/epimorphics/ppd-explorer/issues/244)
+- (Jon) Updated the `lr_common_styles` gem to the latest 1.9.9 patch release.
 - (Jon) Moved all mirrored configuration settings from individual environments
   into the application configuration to reduce the need to manage multiple
   sources of truth


### PR DESCRIPTION
To reflect the unreleased status of the latest changes as well as correlate the updates to the appropriate version cadence where needed this PR includes the CHANGELOG updates needed.
