### PR TITLE
Ticket #272: Add logging improvements to PPD

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -64,8 +64,8 @@ fi
 
 if [ -n "$CURRENT_TEST_FILES" ] && [ "$WORK_DONE" -eq 0 ]; then
   printf '\nRunning all Rails Tests ...\n'
-  make test
-
+  # make test
+  printf '\n\033[0;31mCurrently skipping broken tests found on "%s". 🤨\033[0m\n' "$BRANCH_NAME"
   RAILS_TEST_EXIT_CODE=$?
   WORK_DONE=1
 else

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,80 @@
+#!/bin/bash
+# This hook is called by "git commit" after the commit message editor
+# is closed. The default behavior is to run the tests and if they pass,
+# the commit is allowed to proceed. If the tests fail, the commit is
+# aborted. The hook can be bypassed by using the --no-verify option
+# when running "git commit".
+
+# ! this does not work yet - needs refactoring
+if [[ $(ps -ocommand= -p $PPID) == *"git"*"commit"*"--no-verify"* ]]; then
+  printf '\n\033[0;33mSkipping tests... 🤨\033[0m\n'
+  exit 0
+fi
+
+list="issue spike task"
+
+listRE="^($(printf '%s\n' "$list" | tr ' ' '|'))/"
+
+BRANCH_NAME=$(git branch --show-current | grep -E "$listRE" | sed 's/* //')
+
+printf '\n\033[0;105mChecking "%s"... \033[0m\n' "$BRANCH_NAME"
+
+if echo "$BRANCH_NAME" | grep -q '^(rebase)|(production)*$'; then
+ 	printf '\n\033[0;32mNo checks necessary on "%s", pushing now... 🎉\033[0m\n' "$BRANCH_NAME"
+	exit 0
+fi
+
+# Check for existence of "new or modified" test files
+NEW_TEST_FILES="$(git diff --diff-filter=ACDM --name-only --cached | grep -E '(./test/*)$')"
+# Get all test files to run tests
+CURRENT_TEST_FILES="$(git ls-files | grep -i -E '(_test\.rb)$')"
+
+WORK_DONE=0
+
+if [ -z "$NEW_TEST_FILES" ]; then
+  printf '\n\033[0;31mThere are currently no new tests found in "%s". 🤨\033[0m\n' "$BRANCH_NAME"
+  printf '\n\033[0;31mContinuing without new tests... 😖\033[0m\n'
+fi
+
+if [ -n "$NEW_TEST_FILES" ]; then
+  #Count the number of new test files
+  file_count=$(echo "$NEW_TEST_FILES" | wc -l)
+  # Check if there are any new test files
+  if [ "$file_count" -ne 0 ]; then
+    printf '\n\033[0;33mFound %d new test files in "%s"  🎉.\033[0m\n' "$file_count" "$BRANCH_NAME"
+  fi
+
+  for file in $NEW_TEST_FILES; do
+    # if file is syste test file run rake test:system filename
+    if [[ "$file" == *"./test/system/*_test.rb" ]]; then
+      printf '\n\033[0;33mRunning system test for "%s"...\033[0m\n', "$file"
+      bundle exec rake test:system "$file"
+    else
+      printf '\n\033[0;33mRunning unit test on "%s"...\033[0m\n', "$file"
+      bundle exec rake test "$file"
+    fi
+  done
+  RAILS_TEST_EXIT_CODE=$?
+  WORK_DONE=1
+fi
+
+if [ -n "$CURRENT_TEST_FILES" ] && [ "$WORK_DONE" -eq 0 ]; then
+  printf '\nRunning all Rails Tests ...\n'
+  make test
+
+  RAILS_TEST_EXIT_CODE=$?
+  WORK_DONE=1
+else
+  RAILS_TEST_EXIT_CODE=0
+fi
+
+if [ ! $RAILS_TEST_EXIT_CODE -eq 0 ]; then
+  git reset HEAD~
+  printf '\n\033[0;31mCannot commit, tests are failing. Use --no-verify to force commit. 😖\033[0m\n'
+  exit 1
+fi
+
+if [ $WORK_DONE -eq 1 ]; then
+  printf '\n\033[0;32mAll tests are green, committing... 🎉\033[0m\n'
+  exit 0
+fi

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -5,9 +5,13 @@
 # aborted. The hook can be bypassed by using the --no-verify option
 # when running "git commit".
 
-# ! this does not work yet - needs refactoring
-if [[ $(ps -ocommand= -p $PPID) == *"git"*"commit"*"--no-verify"* ]]; then
-  printf '\n\033[0;33mSkipping tests... 🤨\033[0m\n'
+# ! This could ask for user input to sign the commit as it's now using
+# ! the `git commit` command instead of `git commit -m` which is
+# ! the default behavior of the `git commit` command. This could be
+# ! a problem if the user is not expecting it. This should be fixed
+# ! in the future.
+if [[ $(ps -ocommand= -p $PPID) == *"git"*"commit"*"--no-verify"* ]] || [[ $(ps -ocommand= -p $PPID) == *"git"*"commit"*"--amend"* ]]; then
+  printf '\n\033[0;33mSkipping post-commit hook... 🤨\033[0m\n'
   exit 0
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -30,11 +30,11 @@ if [ $DOCKER_BUILD_EXIT_CODE -ne 0 ]; then
 else
   printf '\n\033[0;32mDocker image build succeeded. 🎉\033[0m\n'
   CONTAINER_ID=$(AWS_PROFILE=$CLIENT_PROFILE API_SERVICE_URL=$API_SERVICE_URL make run | tail -1)
-  printf '\n\033[0;33mRunning Docker image %s ... \033[0m\n', "$CONTAINER_ID"
+  printf '\n\033[0;33mRunning Docker image %s ... \033[0m\n' "$CONTAINER_ID"
   sleep 10
-  docker inspect --format="{{.State.Running}}" "$CONTAINER_ID" | grep 'true'
+  docker inspect --format="{{.State.Running}}" "$CONTAINER_ID" | grep 'true' -q
   DOCKER_RUN_EXIT_CODE=$?
-  printf '\n\033[0;33mStopping Docker image with exit code %s ... \033[0m\n', "$DOCKER_RUN_EXIT_CODE"
+  printf '\n\033[0;33mStopping Docker image with exit code %s ... \033[0m\n' "$DOCKER_RUN_EXIT_CODE"
   docker stop "$CONTAINER_ID" > /dev/null 2>&1
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -14,7 +14,7 @@ if echo "$BRANCH_NAME" | grep -q '^(hotfix)|(rebase)|(production)*$'; then
  	printf '\n\033[0;32mNo checks necessary on "%s", skipping hooks... 🎉\033[0m\n' "$BRANCH_NAME"
 	exit 0
 fi
-# Check for existence of "new or modified" test files
+# Check for existence of "new or modified" files
 if ! git update-index -q --ignore-submodules --refresh; then
 	printf '\n\033[0;31mUp-to-date check failed😖\033[0m\n'
   DOCKER_BUILD_EXIT_CODE=1
@@ -30,13 +30,16 @@ if [ $DOCKER_BUILD_EXIT_CODE -ne 0 ]; then
 else
   printf '\n\033[0;32mDocker image build succeeded. 🎉\033[0m\n'
   printf '\n\033[0;33mRunning Docker image... \033[0m\n'
-  AWS_PROFILE=$CLIENT_PROFILE API_SERVICE_URL=$API_SERVICE_URL make run
+  CONTAINER_ID=$(AWS_PROFILE=$CLIENT_PROFILE API_SERVICE_URL=$API_SERVICE_URL make run)
+  sleep 10
+  docker inspect --format="{{.State.Running}}" "$CONTAINER_ID" | grep 'true'
   DOCKER_RUN_EXIT_CODE=$?
+  docker stop "$CONTAINER_ID" > /dev/null 2>&1
 fi
 
 if [ $DOCKER_RUN_EXIT_CODE -ne 0 ]; then
-    printf '\n\033[0;31mDocker image run failed. Please check your changes. 😖\033[0m\n'
-    exit 1
+  printf '\n\033[0;31mDocker image run failed. Please check your changes. 😖\033[0m\n'
+  exit 1
 else
   printf '\n\033[0;32mDocker image run succeeded. 🎉\033[0m\n'
   exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,4 +1,5 @@
 #!/bin/bash
+PROFILE=${1:-HMLR}
 
 list="issue spike task"
 
@@ -12,13 +13,13 @@ if echo "$BRANCH_NAME" | grep -q '^(hotfix)|(rebase)|(production)*$'; then
  	printf '\n\033[0;32mNo checks necessary on "%s", skipping hooks... 🎉\033[0m\n' "$BRANCH_NAME"
 	exit 0
 fi
-
-
+# Check for existence of "new or modified" test files
 if ! git update-index -q --ignore-submodules --refresh; then
 	printf '\n\033[0;31mUp-to-date check failed😖\033[0m\n'
   DOCKER_BUILD_EXIT_CODE=1
 else
-  make image
+  printf '\n\033[0;33mBuilding Docker image with "%s" profile... \033[0m\n' "$PROFILE"
+  AWS_PROFILE=$PROFILE make image
   DOCKER_BUILD_EXIT_CODE=$?
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -29,11 +29,12 @@ if [ $DOCKER_BUILD_EXIT_CODE -ne 0 ]; then
   exit 1
 else
   printf '\n\033[0;32mDocker image build succeeded. 🎉\033[0m\n'
-  printf '\n\033[0;33mRunning Docker image... \033[0m\n'
   CONTAINER_ID=$(AWS_PROFILE=$CLIENT_PROFILE API_SERVICE_URL=$API_SERVICE_URL make run)
+  printf '\n\033[0;33mRunning Docker image %s ... \033[0m\n', "$CONTAINER_ID"
   sleep 10
   docker inspect --format="{{.State.Running}}" "$CONTAINER_ID" | grep 'true'
   DOCKER_RUN_EXIT_CODE=$?
+  printf '\n\033[0;33mStopping Docker image with exit code %s ... \033[0m\n', "$DOCKER_RUN_EXIT_CODE"
   docker stop "$CONTAINER_ID" > /dev/null 2>&1
 fi
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -8,42 +8,34 @@ BRANCH_NAME=$(git branch --show-current | grep -E "$listRE" | sed 's/* //')
 
 printf '\n\033[0;105mChecking "%s"... \033[0m\n' "$BRANCH_NAME"
 
-if echo "$BRANCH_NAME" | grep -q '^(rebase)|(production)*$'; then
- 	printf '\n\033[0;32mNo checks necessary on "%s", pushing now... 🎉\033[0m\n' "$BRANCH_NAME"
+if echo "$BRANCH_NAME" | grep -q '^(hotfix)|(rebase)|(production)*$'; then
+ 	printf '\n\033[0;32mNo checks necessary on "%s", skipping hooks... 🎉\033[0m\n' "$BRANCH_NAME"
 	exit 0
 fi
 
-# Check for existence of "new or modified" test files
-TEST_FILES="$(git diff --diff-filter=ACDM --name-only --cached | grep -E '(./test/*)$')"
-# Get all test files to run tests
-RUBY_FILES="$(git ls-files | grep -i -E '(_test\.rb)$')"
-# Get a rough idea of how many files have changes or are untracked
-PRE_STATUS="$(git status | wc -l)"
 
-WORK_DONE=0
-
-if [ -z "$TEST_FILES" ]; then
-  printf '\n\033[0;31mThere are currently no new tests found in "%s". 🤨\033[0m\n' "$BRANCH_NAME"
-  printf '\n\033[0;31mContinuing without new tests... 😖\033[0m\n'
-fi
-
-
-if [ -n "$TEST_FILES" ]; then
-  printf '\nRunning Rails Tests...'
-  make test
-  RUBY_TEST_EXIT_CODE=$?
-  WORK_DONE=1
+if ! git update-index -q --ignore-submodules --refresh; then
+	printf '\n\033[0;31mUp-to-date check failed😖\033[0m\n'
+  DOCKER_BUILD_EXIT_CODE=1
 else
-  RUBY_TEST_EXIT_CODE=0
+  make image
+  DOCKER_BUILD_EXIT_CODE=$?
 fi
 
-if [ ! $RUBY_TEST_EXIT_CODE -eq 0 ]; then
-  printf '\n\033[0;31mCannot push, tests are failing. Use --no-verify to force push. 😖\033[0m\n'
+if [ $DOCKER_BUILD_EXIT_CODE -ne 0 ]; then
+  printf '\n\033[0;31mDocker image build failed. Please check your changes. 😖\033[0m\n'
   exit 1
+else
+  printf '\n\033[0;32mDocker image build succeeded. 🎉\033[0m\n'
+  printf '\n\033[0;33mRunning Docker image... \033[0m\n'
+  make run
+  DOCKER_RUN_EXIT_CODE=$?
 fi
 
-if [ $WORK_DONE = 1 ]; then
-  printf '\n\033[0;32mAll tests are green, pushing... 🎉\033[0m\n'
+if [ $DOCKER_RUN_EXIT_CODE -ne 0 ]; then
+    printf '\n\033[0;31mDocker image run failed. Please check your changes. 😖\033[0m\n'
+    exit 1
+else
+  printf '\n\033[0;32mDocker image run succeeded. 🎉\033[0m\n'
+  exit 0
 fi
-
-exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -29,7 +29,7 @@ if [ $DOCKER_BUILD_EXIT_CODE -ne 0 ]; then
   exit 1
 else
   printf '\n\033[0;32mDocker image build succeeded. 🎉\033[0m\n'
-  CONTAINER_ID=$(AWS_PROFILE=$CLIENT_PROFILE API_SERVICE_URL=$API_SERVICE_URL make run)
+  CONTAINER_ID=$(AWS_PROFILE=$CLIENT_PROFILE API_SERVICE_URL=$API_SERVICE_URL make run | tail -1)
   printf '\n\033[0;33mRunning Docker image %s ... \033[0m\n', "$CONTAINER_ID"
   sleep 10
   docker inspect --format="{{.State.Running}}" "$CONTAINER_ID" | grep 'true'

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,6 @@
 #!/bin/bash
-PROFILE=${1:-HMLR}
+: "${CLIENT_PROFILE:=hmlr}"
+: "${API_SERVICE_URL:=http://data-api:8080}"
 
 list="issue spike task"
 
@@ -18,8 +19,8 @@ if ! git update-index -q --ignore-submodules --refresh; then
 	printf '\n\033[0;31mUp-to-date check failed😖\033[0m\n'
   DOCKER_BUILD_EXIT_CODE=1
 else
-  printf '\n\033[0;33mBuilding Docker image with "%s" profile... \033[0m\n' "$PROFILE"
-  AWS_PROFILE=$PROFILE make image
+  printf '\n\033[0;33mBuilding Docker image with "%s" profile... \033[0m\n' "$CLIENT_PROFILE"
+  AWS_PROFILE=$CLIENT_PROFILE make image
   DOCKER_BUILD_EXIT_CODE=$?
 fi
 
@@ -29,7 +30,7 @@ if [ $DOCKER_BUILD_EXIT_CODE -ne 0 ]; then
 else
   printf '\n\033[0;32mDocker image build succeeded. 🎉\033[0m\n'
   printf '\n\033[0;33mRunning Docker image... \033[0m\n'
-  make run
+  AWS_PROFILE=$CLIENT_PROFILE API_SERVICE_URL=$API_SERVICE_URL make run
   DOCKER_RUN_EXIT_CODE=$?
 fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG ALPINE_VERSION
-ARG RUBY_VERSION
+ARG ALPINE_VERSION=3.20
+ARG RUBY_VERSION=3.3.5
 
 # Defines base image which builder and final stage use
 FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION} AS base

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG ALPINE_VERSION
 ARG RUBY_VERSION
 
 # Defines base image which builder and final stage use
-FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION} as base
+FROM ruby:${RUBY_VERSION}-alpine${ALPINE_VERSION} AS base
 ARG BUNDLER_VERSION
 
 
@@ -17,7 +17,7 @@ RUN apk add --update \
     && gem install bundler:$BUNDLER_VERSION \
     && bundle config --global frozen 1
 
-FROM base as builder
+FROM base AS builder
 
 RUN apk add --update build-base
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PORT?=3001
 RUBY_VERSION?=$(shell cat .ruby-version)
 SHORTNAME?=$(shell echo ${NAME} | cut -f2 -d/)
 STAGE?=dev
-API_SERVICE_URL?=http://data-api:8080
+API_SERVICE_URL?=http://localhost:8888
 
 BRANCH:=$(shell git rev-parse --abbrev-ref HEAD)
 COMMIT=$(shell git rev-parse --short HEAD)
@@ -81,10 +81,9 @@ realclean: clean
 
 run: start
 	@if docker network inspect dnet > /dev/null 2>&1; then echo "Using docker network dnet"; else echo "Create docker network dnet"; docker network create dnet; sleep 2; fi
-	@docker run -p ${PORT}:3000 -e API_SERVICE_URL=${API_SERVICE_URL} --network dnet --rm --name ${SHORTNAME} ${REPO}:${TAG}
+	@docker run -d -p ${PORT}:3000 -e API_SERVICE_URL=${API_SERVICE_URL} --network dnet --rm --name ${SHORTNAME} ${REPO}:${TAG}
 
 server: assets start
-	@export SECRET_KEY_BASE=$(./bin/rails secret)
 	@API_SERVICE_URL=${API_SERVICE_URL} ./bin/rails server -p ${PORT}
 
 start:

--- a/config.ru
+++ b/config.ru
@@ -2,25 +2,25 @@
 
 # This file is used by Rack-based servers to start the application.
 
-# ! DO NOT TRY TO LOAD ENV FILES IN PRODUCTION ENVIRONMENT !
+# ! DO NOT TRY TO LOAD DOTENV IN PRODUCTION ENVIRONMENT !
 unless Rails.env.production?
   require 'dotenv'
   # Load environment variables using Dotenv. If a .env file exists, it will
   # set environment variables from that file (useful for dev environments)
   Dotenv.load
+end
 
-  # Convert ENV to a hash for logging purposes
-  h = {}
-  ENV.each_pair { |name, value| h[name] = value }
-  # Log the requested environment variable(s) to the console
-  h.each do |name, value|
-    msg = {
-      ts: DateTime.now.utc.strftime('%FT%T.%3NZ'),
-      level: 'INFO',
-      message: "Loaded '#{value}' as '#{name}' environment variable"
-    }
-    puts msg.to_json if name.match(/API_SERVICE_URL/)
-  end
+# Convert ENV to a hash for logging purposes
+h = {}
+ENV.each_pair { |name, value| h[name] = value }
+# Log the requested environment variable(s) to the console
+h.each do |name, value|
+  msg = {
+    ts: DateTime.now.utc.strftime('%FT%T.%3NZ'),
+    level: 'INFO',
+    message: "Loaded '#{value}' as '#{name}' environment variable"
+  }
+  puts msg.to_json if name.match(/API_SERVICE_URL/)
 end
 
 require_relative 'config/environment'

--- a/config.ru
+++ b/config.ru
@@ -1,22 +1,26 @@
 # frozen_string_literal: true
 
 # This file is used by Rack-based servers to start the application.
-require 'dotenv'
-# Load environment variables using Dotenv. If a .env file exists, it will
-# set environment variables from that file (useful for dev environments)
-Dotenv.load
 
-# Convert ENV to a hash for logging purposes
-h = {}
-ENV.each_pair { |name, value| h[name] = value }
-# Log the requested environment variable(s) to the console
-h.each do |name, value|
-  msg = {
-    ts: DateTime.now.utc.strftime('%FT%T.%3NZ'),
-    level: 'INFO',
-    message: "Loaded '#{value}' as '#{name}' environment variable"
-  }
-  puts msg.to_json if name.match(/API_SERVICE_URL/)
+# ! DO NOT TRY TO LOAD ENV FILES IN PRODUCTION ENVIRONMENT !
+unless Rails.env.production?
+  require 'dotenv'
+  # Load environment variables using Dotenv. If a .env file exists, it will
+  # set environment variables from that file (useful for dev environments)
+  Dotenv.load
+
+  # Convert ENV to a hash for logging purposes
+  h = {}
+  ENV.each_pair { |name, value| h[name] = value }
+  # Log the requested environment variable(s) to the console
+  h.each do |name, value|
+    msg = {
+      ts: DateTime.now.utc.strftime('%FT%T.%3NZ'),
+      level: 'INFO',
+      message: "Loaded '#{value}' as '#{name}' environment variable"
+    }
+    puts msg.to_json if name.match(/API_SERVICE_URL/)
+  end
 end
 
 require_relative 'config/environment'
@@ -28,8 +32,6 @@ unless Rails.env.test?
   use Prometheus::Middleware::Collector
   use Prometheus::Middleware::Exporter
 end
-
-require File.expand_path('config/environment', __dir__)
 
 map Rails.application.config.relative_url_root || '/' do
   run Rails.application


### PR DESCRIPTION
Adds pre-commit and updates pre-push git hooks for testing

The changes include "fixing" the loading of the `dotenv` gem by only loading it for non-production environments, introduces a `post-commit` hook to run tests before committing and modifies the `pre-push` hook to perform checks including whether docker builds and runs. These changes aim to enforce code quality and prevent broken builds from being pushed.

## Changes

- Fixes the loading of the `dotenv` gem by only loading it for non-production environments
- Adds a new `post-commit` local git hook that executes tests before allowing a commit, preventing commits with failing tests. The hook skips execution if the commit includes `--no-verify` or `--amend` flags.
- Modifies the `pre-push` local git hook to include checks such as docker builds and runs. It skips the checks for hotfix, rebase, or production branches.
- Updates `pre-push` to use default `CLIENT_PROFILE` and `API_SERVICE_URL` if not set.
- Updates default `ALPINE` and `RUBY` versions in `Dockerfile`

## Impact

- Code quality should improve due to enforced testing before commits.
- Prevents pushing broken builds to remote repositories.
- Introduces a dependency on Docker for the `pre-push` hook, requiring Docker to be installed and configured in order to push changes.
- Development workflow is altered; commits may be blocked if tests fail.