### PR TITLE
Spike: Resolves open-ended gem versioning warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Resolved open-ended gem versioning warnings by setting explicit minimum
+  versions for Faraday and its middleware dependencies.
+- Updates Faraday follow_redirects to 0.4.0
+
 ## [2.2.3] - 2025-11
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -22,10 +22,12 @@ gem 'haml-rails'
 gem 'rubocop'
 gem 'rubocop-rails'
 
-gem 'faraday', '~> 2.13'
-gem 'faraday-encoding', '>= 0.0.6'
-gem 'faraday-follow_redirects', '>= 0.3.0'
-gem 'faraday-retry', '>= 2.0'
+# Faraday v2 requires individual middlewares to be specified
+# Resolve open-ended gem versioning warnings by setting explicit version minimums
+gem 'faraday', '~> 2.13', '>= 2.13.0'
+gem 'faraday-encoding', '~> 0.0', '>= 0.0.6'
+gem 'faraday-follow_redirects', '~> 0.3', '>= 0.3.0'
+gem 'faraday-retry', '~> 2.0', '>= 2.0'
 
 gem 'font-awesome-rails'
 gem 'get_process_mem'
@@ -84,6 +86,12 @@ group :development do
 
   gem 'flamegraph'
   gem 'memory_profiler'
+
+  # TODO: While running the rails app locally for testing you can set gems to your local path
+  # ! These 'local' paths do not work with a docker image - use the repository version instead
+  # gem 'data_services_api', path: '~/Epimorphics/shared/data_services_api'
+  # gem 'json_rails_logger', path: '~/Epimorphics/shared/json-rails-logger'
+  # gem 'lr_common_styles', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles'
 end
 
 # TODO: In production you want to set this to the gem from the epimorphics package repo
@@ -92,9 +100,3 @@ source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'json_rails_logger'
   gem 'lr_common_styles'
 end
-
-# TODO: While running the rails app locally for testing you can set gems to your local path
-# ! These 'local' paths do not work with a docker image - use the repo instead
-# gem 'data_services_api', path: '~/Epimorphics/shared/data_services_api'
-# gem 'json_rails_logger', path: '~/Epimorphics/shared/json-rails-logger'
-# gem 'lr_common_styles', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       logger
     faraday-encoding (0.0.6)
       faraday
-    faraday-follow_redirects (0.3.0)
+    faraday-follow_redirects (0.4.0)
       faraday (>= 1, < 3)
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
@@ -479,11 +479,11 @@ GEM
 GEM
   remote: https://rubygems.pkg.github.com/epimorphics/
   specs:
-    data_services_api (1.6.0)
-      faraday (~> 2.13)
-      faraday-encoding (~> 0.0.6)
-      faraday-follow_redirects (~> 0.3.0)
-      faraday-retry (~> 2.0)
+    data_services_api (1.6.1)
+      faraday (~> 2.13, >= 2.13.0)
+      faraday-encoding (~> 0.0, >= 0.0.6)
+      faraday-follow_redirects (~> 0.4, >= 0.4.0)
+      faraday-retry (~> 2.0, >= 2.0)
       json (~> 2.0)
       yajl-ruby (~> 1.4)
     json_rails_logger (2.2.0)
@@ -524,10 +524,10 @@ DEPENDENCIES
   data_services_api!
   dotenv
   execjs
-  faraday (~> 2.13)
-  faraday-encoding (>= 0.0.6)
-  faraday-follow_redirects (>= 0.3.0)
-  faraday-retry (>= 2.0)
+  faraday (~> 2.13, >= 2.13.0)
+  faraday-encoding (~> 0.0, >= 0.0.6)
+  faraday-follow_redirects (~> 0.3, >= 0.3.0)
+  faraday-retry (~> 2.0, >= 2.0)
   flamegraph
   font-awesome-rails
   get_process_mem


### PR DESCRIPTION
- Resolves open-ended gem versioning warnings by setting explicit minimum versions for `Faraday` and its middleware dependencies.
- Updates `Faraday follow_redirects` to `0.4.0`.