### PR TITLE
Task: Release v2.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ tags
 .env
 .env*.local
 !.env.development
+
+# Ignore local TODO files
+TODO.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Resolved open-ended gem versioning warnings by setting explicit minimum
+  versions for Faraday and its middleware dependencies.
+- Updates Faraday follow_redirects to 0.4.0
+
 ## [2.2.3] - 2025-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Enabled Sass source maps to simplify front-end debugging in development
+  environment.
+- Included custom initialiser to allow for Autoprefixer complexities and nuances
+  while using latest bootstrap gem
+
+### Changed
+
+- Replaced `bootstrap-sass` with the `bootstrap` gem and remove `sass-rails`,
+  aligning with the new Dart Sass toolchain and reducing deprecated
+  dependencies.
+- Modernised application stylesheets and reformat PPD-specific styles after the
+  Sass migration for consistency.
+- Improved asset compression settings to produce smaller, faster-loading
+  bundles.
+- Updated modal dismissal behaviour and form grouping (including wrapping the
+  email address) following latest Bootstrap notation for cleaner markup and
+  better usability.
+
 ## [2.2.3] - 2025-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-01
+
 ### Added
 
-- Enabled Sass source maps to simplify front-end debugging in development
-  environment.
-- Included custom initialiser to allow for Autoprefixer complexities and nuances
-  while using latest bootstrap gem
+- Enabled Sass source maps for front-end debugging in development
+- Added Autoprefixer initialiser for Bootstrap gem compatibility
+- Added Popper.js dependency for Bootstrap functionality
+- Added `update` Makefile target to check outdated dependencies
+- Added cookie banner styling using Bootstrap conventions
 
 ### Changed
 
-- Replaced `bootstrap-sass` with the `bootstrap` gem and remove `sass-rails`,
-  aligning with the new Dart Sass toolchain and reducing deprecated
-  dependencies.
-- Modernised application stylesheets and reformat PPD-specific styles after the
-  Sass migration for consistency.
-- Improved asset compression settings to produce smaller, faster-loading
-  bundles.
-- Updated modal dismissal behaviour and form grouping (including wrapping the
-  email address) following latest Bootstrap notation for cleaner markup and
-  better usability.
+- Replaced `bootstrap-sass` with `bootstrap` gem for Dart Sass compatibility
+  [#309](https://github.com/epimorphics/ppd-explorer/issues/309)
+- Modernised stylesheets after Sass migration
+- Improved asset compression for smaller bundles
+- Updated modals and forms to Bootstrap 5 notation
+- Enhanced error page layout and status messages
+- Converted form groups to semantic fieldsets for accessibility
+- Replaced deprecated `lighten` with `color.adjust` Sass module
+- Improved page layout padding and form spacing
+- Enhanced action buttons responsiveness
+- Streamlined Makefile with inline help
+- Cleaned up startup log output
+
+### Removed
+
+- Removed `sass-rails` gem and deprecated dependencies
+- Removed duplicated search form partial
 
 ## [2.2.3] - 2025-11
 

--- a/Gemfile
+++ b/Gemfile
@@ -22,10 +22,12 @@ gem 'haml-rails'
 gem 'rubocop'
 gem 'rubocop-rails'
 
-gem 'faraday', '~> 2.13'
-gem 'faraday-encoding', '>= 0.0.6'
-gem 'faraday-follow_redirects', '>= 0.3.0'
-gem 'faraday-retry', '>= 2.0'
+# Faraday v2 requires individual middlewares to be specified
+# Resolve open-ended gem versioning warnings by setting explicit version minimums
+gem 'faraday', '~> 2.13', '>= 2.13.0'
+gem 'faraday-encoding', '~> 0.0', '>= 0.0.6'
+gem 'faraday-follow_redirects', '~> 0.3', '>= 0.3.0'
+gem 'faraday-retry', '~> 2.0', '>= 2.0'
 
 gem 'font-awesome-rails'
 gem 'get_process_mem'
@@ -84,6 +86,12 @@ group :development do
 
   gem 'flamegraph'
   gem 'memory_profiler'
+
+  # TODO: While running the rails app locally for testing you can set gems to your local path
+  # ! These 'local' paths do not work with a docker image - use the repository version instead
+  # gem 'data_services_api', path: '~/Epimorphics/shared/data_services_api'
+  # gem 'json_rails_logger', path: '~/Epimorphics/shared/json-rails-logger'
+  # gem 'lr_common_styles', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles'
 end
 
 # TODO: In production you want to set this to the gem from the epimorphics package repo
@@ -92,9 +100,3 @@ source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'json_rails_logger'
   gem 'lr_common_styles'
 end
-
-# TODO: While running the rails app locally for testing you can set gems to your local path
-# ! These 'local' paths do not work with a docker image - use the repo instead
-# gem 'data_services_api', path: '~/Epimorphics/shared/data_services_api'
-# gem 'json_rails_logger', path: '~/Epimorphics/shared/json-rails-logger'
-# gem 'lr_common_styles', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles'

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'jquery-rails'
 
 gem 'autoprefixer-rails'
 gem 'bootstrap', '~> 5.3.2'
+gem 'dartsass-sprockets', '~> 3.2'
 
 gem 'haml-rails'
 
@@ -85,6 +86,12 @@ group :development do
 
   gem 'flamegraph'
   gem 'memory_profiler'
+
+  # TODO: While running the rails app locally for testing you can set gems to your local path
+  # ! These 'local' paths do not work with a docker image - use the repo instead
+  # gem 'data_services_api', path: '~/Epimorphics/shared/data_services_api'
+  # gem 'json_rails_logger', path: '~/Epimorphics/shared/json-rails-logger'
+  # gem 'lr_common_styles', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles'
 end
 
 # TODO: In production you want to set this to the gem from the epimorphics package repo
@@ -93,11 +100,3 @@ source 'https://rubygems.pkg.github.com/epimorphics' do
   gem 'json_rails_logger'
   gem 'lr_common_styles'
 end
-
-# TODO: While running the rails app locally for testing you can set gems to your local path
-# ! These 'local' paths do not work with a docker image - use the repo instead
-# gem 'data_services_api', path: '~/Epimorphics/shared/data_services_api'
-# gem 'json_rails_logger', path: '~/Epimorphics/shared/json-rails-logger'
-# gem 'lr_common_styles', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles'
-
-gem "dartsass-sprockets", "~> 3.2"

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,9 @@ gem 'libv8-node'
 gem 'jbuilder'
 gem 'jquery-rails'
 
-gem 'bootstrap-sass'
+gem 'autoprefixer-rails'
+gem 'bootstrap', '~> 5.3.2'
+
 gem 'haml-rails'
 
 gem 'rubocop'

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ gem 'sentry-rails' # rubocop:disable Bundler/OrderedGems
 # Assets group is temporarily disabled due to versioning issues with Rails
 # group :assets do
 # Use SCSS for stylesheets
-gem 'sass-rails'
 # ! Webpacker removes the need for Uglifier so we can safely remove it.
 # ! If you want to use Uglifier, uncomment the line below
 # ! and ensure you have the 'uglifier' gem in your Gemfile.
@@ -98,3 +97,5 @@ end
 # gem 'data_services_api', path: '~/Epimorphics/shared/data_services_api'
 # gem 'json_rails_logger', path: '~/Epimorphics/shared/json-rails-logger'
 # gem 'lr_common_styles', path: '~/Epimorphics/clients/land-registry/projects/lr_common_styles'
+
+gem "dartsass-sprockets", "~> 3.2"

--- a/Gemfile
+++ b/Gemfile
@@ -8,16 +8,16 @@ gem 'rails'
 # Use Puma as the app server
 gem 'puma'
 
-# See https://github.com/sstephenson/execjs#readme for more supported runtimes
+# See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'execjs'
 # gem 'therubyracer', platforms: :ruby
 gem 'libv8-node'
 
+# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder'
 gem 'jquery-rails'
 
 gem 'autoprefixer-rails'
-gem 'bootstrap', '~> 5.3.2'
 gem 'dartsass-sprockets', '~> 3.2'
 
 gem 'haml-rails'
@@ -41,17 +41,6 @@ gem 'yajl-ruby', require: 'yajl'
 # Sentry uses stackprof for performance profiling, has to be loaded before Sentry
 gem 'stackprof'
 gem 'sentry-rails' # rubocop:disable Bundler/OrderedGems
-
-# Assets group is temporarily disabled due to versioning issues with Rails
-# group :assets do
-# Use SCSS for stylesheets
-# ! Webpacker removes the need for Uglifier so we can safely remove it.
-# ! If you want to use Uglifier, uncomment the line below
-# ! and ensure you have the 'uglifier' gem in your Gemfile.
-# ! See https://www.mintbit.com/blog/rails-5-6-upgrade-es6-uglifier-bug/
-# Use Uglifier as compressor for JavaScript assets
-# gem 'uglifier', require: false
-# end
 
 group :doc do
   gem 'sdoc', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,9 +96,6 @@ GEM
     bigdecimal (3.3.1)
     bootstrap (5.3.5)
       popper_js (>= 2.11.8, < 3)
-    bootstrap-sass (3.4.1)
-      autoprefixer-rails (>= 5.2.1)
-      sassc (>= 2.0.0)
     builder (3.3.0)
     byebug (12.0.0)
     capybara (3.40.0)
@@ -427,18 +424,8 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
     sassc-embedded (1.80.8)
       sass-embedded (~> 1.80)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     sdoc (2.6.5)
       rdoc (>= 5.0)
     securerandom (0.4.1)
@@ -538,8 +525,8 @@ GEM
       json
       lograge
       railties
-    lr_common_styles (2.3.1)
-      bootstrap-sass (~> 3.4.1)
+    lr_common_styles (3.0.0)
+      bootstrap (~> 5.3.2)
       font-awesome-rails (~> 4.7.0)
       govuk_elements_rails (= 3.0.2)
       govuk_frontend_toolkit (~> 9.0)
@@ -550,7 +537,6 @@ GEM
       modernizr-rails (~> 2.7)
       modulejs-rails (~> 2.2.0)
       rails (~> 8.0)
-      sass-rails (~> 6.0)
 
 PLATFORMS
   aarch64-linux
@@ -566,7 +552,6 @@ PLATFORMS
 
 DEPENDENCIES
   autoprefixer-rails
-  bootstrap (~> 5.3.2)
   byebug
   capybara
   csv

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       logger
     faraday-encoding (0.0.6)
       faraday
-    faraday-follow_redirects (0.3.0)
+    faraday-follow_redirects (0.4.0)
       faraday (>= 1, < 3)
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
@@ -479,11 +479,11 @@ GEM
 GEM
   remote: https://rubygems.pkg.github.com/epimorphics/
   specs:
-    data_services_api (1.6.0)
-      faraday (~> 2.13)
-      faraday-encoding (~> 0.0.6)
-      faraday-follow_redirects (~> 0.3.0)
-      faraday-retry (~> 2.0)
+    data_services_api (1.6.1)
+      faraday (~> 2.13, >= 2.13.0)
+      faraday-encoding (~> 0.0, >= 0.0.6)
+      faraday-follow_redirects (~> 0.4, >= 0.4.0)
+      faraday-retry (~> 2.0, >= 2.0)
       json (~> 2.0)
       yajl-ruby (~> 1.4)
     json_rails_logger (2.2.0)
@@ -524,10 +524,10 @@ DEPENDENCIES
   data_services_api!
   dotenv
   execjs
-  faraday (~> 2.13)
-  faraday-encoding (>= 0.0.6)
-  faraday-follow_redirects (>= 0.3.0)
-  faraday-retry (>= 2.0)
+  faraday (~> 2.13, >= 2.13.0)
+  faraday-encoding (~> 0.0, >= 0.0.6)
+  faraday-follow_redirects (~> 0.3, >= 0.3.0)
+  faraday-retry (~> 2.0, >= 2.0)
   flamegraph
   font-awesome-rails
   get_process_mem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
     base64 (0.3.0)
     benchmark (0.5.0)
     bigdecimal (3.3.1)
+    bootstrap (5.3.5)
+      popper_js (>= 2.11.8, < 3)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
@@ -300,6 +302,7 @@ GEM
     parser (3.3.10.0)
       ast (~> 2.4.1)
       racc
+    popper_js (2.11.8)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -562,7 +565,8 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  bootstrap-sass
+  autoprefixer-rails
+  bootstrap (~> 5.3.2)
   byebug
   capybara
   csv

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,12 @@ GEM
       rexml
     crass (1.0.6)
     csv (3.3.5)
+    dartsass-sprockets (3.2.1)
+      railties (>= 4.0.0)
+      sassc-embedded (~> 1.80.1)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     date (3.5.0)
     diff-lcs (1.6.2)
     docile (1.4.1)
@@ -151,6 +157,27 @@ GEM
       ffi (~> 1.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    google-protobuf (4.33.2)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.2-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
     govuk_elements_rails (3.0.2)
       govuk_frontend_toolkit (>= 5.2.0)
       rails (>= 4.1.0)
@@ -378,6 +405,22 @@ GEM
     rubyzip (3.2.2)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
+    sass-embedded (1.97.1-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.1-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -385,6 +428,8 @@ GEM
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sassc-embedded (1.80.8)
+      sass-embedded (~> 1.80)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -521,6 +566,7 @@ DEPENDENCIES
   byebug
   capybara
   csv
+  dartsass-sprockets (~> 3.2)
   data_services_api!
   dotenv
   execjs
@@ -555,7 +601,6 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   ruby-lsp
-  sass-rails
   sdoc
   selenium-webdriver
   sentry-rails

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
 .PHONY:	assets auth check clean image lint publish realclean run tag test update vars
 
-ACCOUNT?=$(shell aws sts get-caller-identity | jq -r .Account)
 ALPINE_VERSION?=3.22
-AWS_REGION?=eu-west-1
 BUNDLER_VERSION?=$(shell tail -1 Gemfile.lock | tr -d ' ')
+RUBY_VERSION?=$(shell cat .ruby-version)
+ACCOUNT?=$(shell aws sts get-caller-identity | jq -r .Account)
+AWS_REGION?=eu-west-1
 ECR?=${ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
 GPR_OWNER?=epimorphics
 NAME?=$(shell awk -F: '$$1=="name" {print $$2}' deployment.yaml | sed -e 's/[[:blank:]]//g')
 PAT?=$(shell read -p 'Github access token:' TOKEN; echo $$TOKEN)
 PORT?=3001
-RUBY_VERSION?=$(shell cat .ruby-version)
+
 SHORTNAME?=$(shell echo ${NAME} | cut -f2 -d/)
 STAGE?=dev
 API_SERVICE_URL?=http://localhost:8888
@@ -24,9 +25,9 @@ TAG?=$(shell printf '%s_%s_%08d' ${VERSION} ${COMMIT} ${GITHUB_RUN_NUMBER})
 IMAGE?=${NAME}/${STAGE}
 REPO?=${ECR}/${IMAGE}
 
-GITHUB_TOKEN=.github-token
 BUNDLE_CFG=.bundle/config
 BUNDLE=./bin/bundle
+GITHUB_TOKEN=.github-token
 RAILS=./bin/rails
 
 ${BUNDLE_CFG}: ${GITHUB_TOKEN}
@@ -35,20 +36,25 @@ ${BUNDLE_CFG}: ${GITHUB_TOKEN}
 ${GITHUB_TOKEN}:
 	@echo ${PAT} > ${GITHUB_TOKEN}
 
-all: image
+all: image ## Default target: build the Docker image
 
-assets:
-	@echo "Installing bundled gems ..."
+assets: bundles compiled ## Compile assets for serving
+	@echo assets completed.
+
+auth: ${GITHUB_TOKEN} ${BUNDLE_CFG} ## Set up authentication for GitHub and Bundler
+	@echo "Authentication set up for GitHub and Bundler."
+
+bundles: ## Install Ruby gems via Bundler
+	@echo "Installing Ruby gems via Bundler..."
 	@${BUNDLE} install
-	@echo "Cleaning and precompiling static assets ..."
-	@${BUNDLE} exec rake assets:clean assets:precompile
 
-auth: ${GITHUB_TOKEN} ${BUNDLE_CFG}
-
-check: lint test
+check: checks ## Alias for `checks` target
 	@echo "All checks passed."
 
-clean:
+checks: lint test ## Run all checks: linting and tests
+	@echo "All checks passed."
+
+clean: ## Clean up temporary and compiled files
 	@echo "Cleaning up ${SHORTNAME} files..."
 # Clean up the project
 	@[ -d public/assets ] && ${RAILS} assets:clobber || :
@@ -57,7 +63,21 @@ clean:
 # Remove temporary files and directories
 	@@ rm -rf bundle coverage log node_modules tmp
 
-image: auth
+compiled: ## Compile assets for production
+	@echo "Cleaning and precompiling static assets ..."
+	@${RAILS} assets:clobber assets:precompile
+
+forceclean: realclean ## Remove all bundled files
+	@${BUNDLE} clean --force || :
+
+help: ## Display this message
+	@echo "Available make targets:"
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-20s %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Environment variables (optional: all variables have defaults):"
+	@make vars
+
+image: auth ## Build the Docker image
 	@echo Building ${REPO}:${TAG} ...
 	@docker build \
 		--build-arg ALPINE_VERSION=${ALPINE_VERSION} \
@@ -73,48 +93,50 @@ image: auth
 		.
 	@echo Done.
 
-forceclean: realclean
-# Remove all bundled files
-	@${BUNDLE} clean --force || :
+lint: rubocop ## Run linting checks
+	@echo "All linting complete."
 
-lint: assets
-	@${BUNDLE} exec rubocop
-
-name:
+name: ## Display the shortname of the application
 	@echo ${SHORTNAME}
 
-publish: image
+publish: image ## Publish the Docker image to the registry
 	@echo Publishing image: ${REPO}:${TAG} ...
 	@docker tag ${NAME}:${TAG} ${REPO}:${TAG} 2>&1
 	@docker push ${REPO}:${TAG} 2>&1
 	@echo Done.
 
-realclean: clean
+realclean: clean ## Remove all generated files and authentication
 	@echo "Removing authentication from ${SHORTNAME}..."
 	@rm -f ${GITHUB_TOKEN} ${BUNDLE_CFG}
 
-run: start
+rubocop: ## Run RuboCop linting
+	@echo "Running RuboCop linting for ${SHORTNAME} ..."
+# Auto-correct offenses safely where possible with the `-a` flag
+	@${BUNDLE} exec rubocop -a
+
+run: start ## Run the Docker container locally
 	@if docker network inspect dnet > /dev/null 2>&1; then echo "Using docker network dnet"; else echo "Create docker network dnet"; docker network create dnet; sleep 2; fi
 	@docker run ${RUN_VARS} ${PORT}:3000 --env API_SERVICE_URL=${API_SERVICE_URL} --network dnet --rm --name ${SHORTNAME} ${REPO}:${TAG}
 
-server: start
+server: start ## Run the Rails server locally
 	@API_SERVICE_URL=${API_SERVICE_URL} ${RAILS} server -p ${PORT}
 
-start: stop
+start: stop ## Start the application
 	@echo "Starting ${SHORTNAME} pointing to ${API_SERVICE_URL} API ..."
 
-stop:
+stop: ## Stop the application
 	@echo "Stopping ${SHORTNAME} ..."
 	@docker stop ${SHORTNAME} > /dev/null 2>&1 || :
 
-tag:
+tag: ## Display the Docker image tag
 	@echo ${TAG}
 
-test: assets
-	@echo "Running tests ..."
+test: ## Run unit tests
+	@echo "Running unit tests ..."
+# Run Rails tests
 	@${RAILS} test
 
-update:
+update: ## Review and update dependencies interactively
 	@echo "Checking for outdated dependencies..."
 	@if [ -f package.json ]; then \
 		echo "Running yarn upgrade-interactive..."; \
@@ -123,7 +145,7 @@ update:
 	@echo "Running bundle outdated to check Ruby gems..."
 	@bundle outdated --only-explicit
 
-vars:
+vars: ## Display environment variables
 	@echo "Docker: ${REPO}:${TAG}"
 	@echo "ACCOUNT = ${ACCOUNT}"
 	@echo "ALPINE_VERSION = ${ALPINE_VERSION}"
@@ -140,5 +162,5 @@ vars:
 	@echo "TAG = ${TAG}"
 	@echo "VERSION = ${VERSION}"
 
-version:
+version: ## Display the application version
 	@echo ${VERSION}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY:	assets auth check clean image lint publish realclean run tag test vars
+.PHONY:	assets auth check clean image lint publish realclean run tag test update vars
 
 ACCOUNT?=$(shell aws sts get-caller-identity | jq -r .Account)
 ALPINE_VERSION?=3.22
@@ -113,6 +113,15 @@ tag:
 test: assets
 	@echo "Running tests ..."
 	@${RAILS} test
+
+update:
+	@echo "Checking for outdated dependencies..."
+	@if [ -f package.json ]; then \
+		echo "Running yarn upgrade-interactive..."; \
+		yarn upgrade-interactive; \
+	fi
+	@echo "Running bundle outdated to check Ruby gems..."
+	@bundle outdated --only-explicit
 
 vars:
 	@echo "Docker: ${REPO}:${TAG}"

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require popper
 //= require bootstrap
 //= require lr_common_styles/application
 //= require_tree .

--- a/app/assets/stylesheets/_search-form.scss
+++ b/app/assets/stylesheets/_search-form.scss
@@ -1,8 +1,0 @@
-.search-form-actions {
-  margin-top: 1.5em;
-  display: flex;
-
-  > * {
-    margin-left: 0.75em;
-  }
-}

--- a/app/assets/stylesheets/_workflow-actions.scss
+++ b/app/assets/stylesheets/_workflow-actions.scss
@@ -1,8 +1,29 @@
-.workflow-actions {
+.workflow-actions,
+.search-form-actions {
+  margin-block: 1.0em;
   display: flex;
-  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.0rem;
+  justify-content: center;
 
-  > * {
-    margin-left: 0.75em;
+  .button {
+    flex: 0 0 auto;
+    width: 90%;
   }
+
+  .search-form-action {
+    > .button {
+      width: auto;
+    }
+  }
+
+  @media (min-width: 576px) {
+    row-gap: 0;
+    justify-content: flex-end;
+
+    .button {
+      width: auto;
+    }
+  }
+
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,5 @@
 @import "lr_common_styles/lr-common";
 @import "gov-uk-tweaks";
 @import "ppd";
-@import 'search-form';
 @import 'search-results';
 @import 'workflow-actions';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,15 +2,13 @@
  *= require jquery-ui
  */
 
-@import
-  "govuk-template",
-  "govuk-elements",
-  "bootstrap-sprockets",
-  "bootstrap",
-  "font-awesome",
-  "lr_common_styles/lr-common",
-  "gov-uk-tweaks",
-  "ppd",
-  'search-form',
-  'search-results',
-  'workflow-actions';
+@import "govuk-template";
+@import "govuk-elements";
+@import "bootstrap";
+@import "font-awesome";
+@import "lr_common_styles/lr-common";
+@import "gov-uk-tweaks";
+@import "ppd";
+@import 'search-form';
+@import 'search-results';
+@import 'workflow-actions';

--- a/app/assets/stylesheets/ppd.scss
+++ b/app/assets/stylesheets/ppd.scss
@@ -242,3 +242,184 @@ $lr-logo-grey: #a7a5a6;
   }
 }
 
+
+// Style Updates 2026 Post-Sass Migration
+@media (min-width: 1200px) {
+
+  h1,
+  .h1 {
+    font-size: 3.6rem;
+  }
+
+  h2,
+  .h2 {
+    font-size: 3rem;
+  }
+
+  h3,
+  .h3 {
+    font-size: 2.4rem;
+  }
+
+  h4,
+  .h4 {
+    font-size: 2rem;
+  }
+
+  h5,
+  .h5 {
+    font-size: 1.6rem;
+  }
+
+  h6,
+  .h6 {
+    font-size: 1.4rem;
+  }
+}
+
+
+.form-group {
+  display: flex;
+  gap: 3rem;
+
+  .form-horizontal & {
+    margin-right: -15px;
+    margin-left: -15px;
+  }
+}
+
+label {
+  display: inline-block;
+  max-width: 100%;
+  margin-bottom: 5px;
+  font-weight: 700;
+
+  &:has(input[type="checkbox"]),
+  &:has(input[type="radio"]) {
+    font-weight: 400;
+  }
+
+  &:has(input[type="date"]) {
+    line-height: 2;
+    ;
+  }
+}
+
+@media (min-width: 768px) {
+  .form-horizontal .control-label {
+    line-height: 2.2;
+    margin-bottom: 0;
+    text-align: right;
+  }
+}
+
+.form-control {
+  width: 100%;
+  height: 34px;
+  padding: 6px 12px;
+  font-size: 1.4rem;
+  line-height: 1.428571429;
+  color: #555555;
+  background-color: #fff;
+  background-image: none;
+}
+
+.form-control::-webkit-input-placeholder {
+  color: #999;
+}
+
+
+.lr form.ppd ul.list-inline {
+  display: inline-flex;
+  gap: 1.5rem;
+}
+
+
+.input-group .input-group-addon {
+  @extend .input-group-text;
+  font-size: 1.4rem;
+  padding-inline: 1.2rem;
+}
+
+.form-horizontal .radio,
+.form-horizontal .checkbox {
+  min-height: 27px;
+}
+
+.form-horizontal .radio,
+.form-horizontal .checkbox,
+.form-horizontal .radio-inline,
+.form-horizontal .checkbox-inline {
+  padding-top: 7px;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+@media (min-width: 768px) {
+  .modal {
+    --bs-modal-width: 600px;
+    --bs-modal-padding: 1.75rem;
+
+    .btn {
+      font-size: 1.4rem;
+    }
+  }
+
+  .modal-dialog {
+    width: 600px;
+    margin: 30px auto;
+  }
+}
+
+.modal-header {
+  flex-direction: row-reverse;
+  justify-content: space-between;
+
+  button.close {
+    align-self: flex-start;
+  }
+}
+
+.modal-footer {
+  align-items: end;
+}
+
+button.close {
+  padding: 0;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.close {
+  float: right;
+  font-size: 21px;
+  font-weight: bold;
+  line-height: 1;
+  color: #000;
+  text-shadow: 0 1px 0 #fff;
+  filter: alpha(opacity=20);
+  opacity: 0.2;
+}
+
+#help-modal .dl-horizontal {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.5rem;
+    margin-block-end: 2rem;
+
+  dt {
+    flex: 0 0 10%;
+    max-width: 10%;
+    font-weight: 700;
+    text-align: end;
+  }
+
+  dd {
+    flex: 0 0 75%;
+    max-width: 75%;
+    margin-left: 0;
+  }
+}

--- a/app/assets/stylesheets/ppd.scss
+++ b/app/assets/stylesheets/ppd.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 $lr-logo-grey: #a7a5a6;
 
 @media (min-width: 641px) {
@@ -178,7 +180,7 @@ $lr-logo-grey: #a7a5a6;
   }
 
   .transaction-category {
-    background-color: lighten($lr-logo-grey, 20%);
+    background-color: color.adjust($lr-logo-grey, $lightness: 20%);
     padding: 3px;
     border-radius: 3px;
   }
@@ -244,49 +246,37 @@ $lr-logo-grey: #a7a5a6;
 
 
 // Style Updates 2026 Post-Sass Migration
-@media (min-width: 1200px) {
 
-  h1,
-  .h1 {
-    font-size: 3.6rem;
-  }
-
-  h2,
-  .h2 {
-    font-size: 3rem;
-  }
-
-  h3,
-  .h3 {
-    font-size: 2.4rem;
-  }
-
-  h4,
-  .h4 {
-    font-size: 2rem;
-  }
-
-  h5,
-  .h5 {
-    font-size: 1.6rem;
-  }
-
-  h6,
-  .h6 {
-    font-size: 1.4rem;
-  }
+h1,
+.h1 {
+  font-size: 3.6rem;
 }
 
-
-.form-group {
-  display: flex;
-  gap: 3rem;
-
-  .form-horizontal & {
-    margin-right: -15px;
-    margin-left: -15px;
-  }
+h2,
+.h2 {
+  font-size: 3rem;
 }
+
+h3,
+.h3 {
+  font-size: 2.4rem;
+}
+
+h4,
+.h4 {
+  font-size: 2rem;
+}
+
+h5,
+.h5 {
+  font-size: 1.6rem;
+}
+
+h6,
+.h6 {
+  font-size: 1.4rem;
+}
+
 
 label {
   display: inline-block;
@@ -301,17 +291,55 @@ label {
 
   &:has(input[type="date"]) {
     line-height: 2;
-    ;
+  }
+}
+
+@media (max-width: 768px) {
+  .control-legend {
+    margin-block-end: 0;
+    padding-block-end: 0.75rem;
   }
 }
 
 @media (min-width: 768px) {
-  .form-horizontal .control-label {
-    line-height: 2.2;
-    margin-bottom: 0;
-    text-align: right;
+
+  .form-horizontal {
+    .form-group {
+      display: flex;
+      gap: 3rem;
+      margin-right: -15px;
+      margin-left: -15px;
+    }
+
+    .control-label {
+      line-height: 2.2;
+      margin-bottom: 0;
+      text-align: right;
+    }
+
+    .radio,
+    .checkbox {
+      min-height: 27px;
+    }
+
+    .radio,
+    .checkbox,
+    .radio-inline,
+    .checkbox-inline {
+      padding-top: 7px;
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+
   }
 }
+
+.lr form.ppd ul.list-inline {
+  display: inline-flex;
+  gap: 0.25rem 1.5rem;
+  flex-wrap: wrap
+}
+
 
 .form-control {
   width: 100%;
@@ -328,33 +356,13 @@ label {
   color: #999;
 }
 
-
-.lr form.ppd ul.list-inline {
-  display: inline-flex;
-  gap: 1.5rem;
-}
-
-
 .input-group .input-group-addon {
-  @extend .input-group-text;
+  @extend .input-group-text !optional;
   font-size: 1.4rem;
   padding-inline: 1.2rem;
 }
 
-.form-horizontal .radio,
-.form-horizontal .checkbox {
-  min-height: 27px;
-}
-
-.form-horizontal .radio,
-.form-horizontal .checkbox,
-.form-horizontal .radio-inline,
-.form-horizontal .checkbox-inline {
-  padding-top: 7px;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
+// Modal styles
 @media (min-width: 768px) {
   .modal {
     --bs-modal-width: 600px;
@@ -405,10 +413,10 @@ button.close {
 }
 
 #help-modal .dl-horizontal {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem 1.5rem;
-    margin-block-end: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+  margin-block-end: 2rem;
 
   dt {
     flex: 0 0 10%;
@@ -422,4 +430,9 @@ button.close {
     max-width: 75%;
     margin-left: 0;
   }
+}
+
+// Lists
+.list-bullet {
+    list-style-position: outside;
 }

--- a/app/assets/stylesheets/ppd.scss
+++ b/app/assets/stylesheets/ppd.scss
@@ -2,8 +2,8 @@ $lr-logo-grey: #a7a5a6;
 
 @media (min-width: 641px) {
   .lr main {
-      font-size: 16px;
-      line-height: 1.31578947;
+    font-size: 16px;
+    line-height: 1.31578947;
   }
 }
 
@@ -14,10 +14,11 @@ $lr-logo-grey: #a7a5a6;
 
 .control-legend {
   border: none;
-  font-size: 16px;
+  font-size: 1.6rem;
   line-height: 1.31578947;
   font-family: "nta", Arial, sans-serif;
   font-weight: bold;
+
   @media (max-width: 768px) {
     margin-block-end: 0;
   }
@@ -32,7 +33,8 @@ $lr-logo-grey: #a7a5a6;
     margin-top: 10px;
   }
 
-  h2, h3 {
+  h2,
+  h3 {
     margin-top: 8px;
   }
 
@@ -81,20 +83,20 @@ $lr-logo-grey: #a7a5a6;
     }
   }
 
-  .search-selection > span {
+  .search-selection>span {
     margin-left: 10px;
   }
 
- .detailed-address {
+  .detailed-address {
     table {
       td {
         border: 0;
         padding: 2px;
       }
 
-    .property-details-field-title {
-      padding-right: 10px;
-    }
+      .property-details-field-title {
+        padding-right: 10px;
+      }
 
     }
 
@@ -114,7 +116,10 @@ $lr-logo-grey: #a7a5a6;
   }
 
   .ppd-results {
-    h2, h3, h4 {
+
+    h2,
+    h3,
+    h4 {
       font-family: Arial, sans-serif;
     }
 
@@ -173,7 +178,7 @@ $lr-logo-grey: #a7a5a6;
   }
 
   .transaction-category {
-    background-color: lighten( $lr-logo-grey, 20% );
+    background-color: lighten($lr-logo-grey, 20%);
     padding: 3px;
     border-radius: 3px;
   }
@@ -190,7 +195,7 @@ $lr-logo-grey: #a7a5a6;
   }
 
   .social-media {
-    > div {
+    >div {
       display: inline-block;
       vertical-align: top !important;
       height: 20px;
@@ -206,6 +211,7 @@ $lr-logo-grey: #a7a5a6;
     dt {
       width: 60px;
     }
+
     dd {
       margin-left: 80px;
     }
@@ -229,8 +235,10 @@ $lr-logo-grey: #a7a5a6;
 .footnotes {
   p {
     margin-inline: 15px;
+
     @media (min-width: 768px) {
       margin-inline: 0;
     }
   }
 }
+

--- a/app/assets/stylesheets/ppd.scss
+++ b/app/assets/stylesheets/ppd.scss
@@ -436,3 +436,10 @@ button.close {
 .list-bullet {
     list-style-position: outside;
 }
+
+.cookie-banner {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: initial;
+  padding-inline: 3rem;
+  border-bottom: 1px solid #e5e5e5;
+}

--- a/app/lib/version.rb
+++ b/app/lib/version.rb
@@ -2,8 +2,8 @@
 
 module Version
   MAJOR = 2
-  MINOR = 2
-  PATCH = 3
+  MINOR = 3
+  PATCH = 0
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}".freeze
 end

--- a/app/views/exceptions/error_page.html.haml
+++ b/app/views/exceptions/error_page.html.haml
@@ -1,57 +1,65 @@
 - puts "Rendering error page with status: #{status.inspect}" if Rails.env.development?
 - content_for(:current_environment_title, EnvironmentHelper.environment_title)
 
-%article.u-clear
-  - if status == 400
-    %h1.o-heading--1 Request not understood
-    %p
-      We're sorry, but the request you made was not understood. If you are requesting
-      data via a script or program, please check the URL parameters. If you see this
-      message as a result of using the HPI or PPD applications, please let us
-      know so that we can correct the problem.
+.row.mx-3.my-5
+  .col-md-12
+    %article.u-clear
+      - if status == 400
+        %h1.o-heading--1 Request not understood
+        %p
+          We're sorry, but the request you made was not understood. If you are requesting
+          data via a script or program, please check the URL parameters. If you see this
+          message as a result of using the HPI or PPD applications, please let us
+          know so that we can correct the problem.
 
-  - elsif status == 403
-    %h1.o-heading--1 Forbidden
+      - elsif status == 403
+        %h1.o-heading--1 Request denied
 
-    %p
-      We're sorry, but it seems you don't have permission to access this resource.
-      Please check the spelling of the page address (URL). If you require further
-      assistance, please see the contact details below.
+        %p
+          We're sorry, but it seems you don't have permission to access this resource.
+          Please check the spelling of the page address (URL). If you require further
+          assistance, please see the contact details below.
 
-  - elsif status == 404
-    %h1.o-heading--1 Page not found
+      - elsif status == 404
+        %h1.o-heading--1 Page not found
 
-    %p
-      We're sorry, but the web page you requested is not present on our server.
-      Please check the spelling of the page address (URL). If you require further
-      assistance, please see the contact details below.
+        %p
+          We're sorry, but the web page you requested is not present on our server.
+          Please check the spelling of the page address (URL). If you require further
+          assistance, please see the contact details below.
 
-  - else
-    %h1.o-heading--1 Application error
+      - elsif status == 422
+        %h1.o-heading--1 The change you wanted was rejected.
+        %p
+          Maybe you tried to change something you didn't have access to? If you are
+          the application owner, check the logs for more information.
 
-    %p
-      We're very sorry, but the request you just made resulted in an internal error
-      in the application. If this problem persists, please use one of the contact
-      methods below to report the problem to us, so that we can resolve it and
-      help you get the data you require.
+      - else
+        %h1.o-heading--1 Application error
 
-  - if sentry_code
-    %h2.o-heading--3 Reference code
-    %p
-      If you need to contact support staff about this issue, please use the following
-      code to identify the problem:
-      %code
-        = sentry_code
+        %p
+          We're very sorry, but the request you just made resulted in an internal error
+          in the application. If this problem persists, please use one of the contact
+          methods below to report the problem to us, so that we can resolve it and
+          help you get the data you require.
 
-  %h2.o-heading--2 Who to contact
-  %ul.list.list-bullet
-    %li
-      If you are unable to access the data, please
-      %a{ href: '//site.landregistry.gov.uk/contact-us/form' }
-        fill in our contact form.
-    %li
-      For general transaction data enquiries, email
-      = mail_to('DRO@landregistry.gov.uk')
-    %li
-      For general price paid data enquiries, contact
-      = mail_to(Rails.application.config.contact_email_address)
+      - if sentry_code
+        %h2.o-heading--3 Reference code
+        %p
+          If you need to contact support staff about this issue, please use the following
+          code to identify the problem:
+          %code
+            = sentry_code
+
+      %h2.o-heading--2 Who to contact
+      %ul.list.list-bullet
+        %li
+          If you are unable to access the data, please
+          %a{ href: '//site.landregistry.gov.uk/contact-us/form' }
+            fill in our contact form.
+        %li
+          For general transaction data enquiries, email
+          = mail_to('DRO@landregistry.gov.uk')
+        %li
+          For general price paid data enquiries, contact
+          = mail_to(Rails.application.config.contact_email_address)

--- a/app/views/ppd/_bookmark_modal.html.haml
+++ b/app/views/ppd/_bookmark_modal.html.haml
@@ -3,13 +3,13 @@
 #bookmark-modal.modal
   #bookmark-dialog.modal-dialog{role: "dialog", "aria-labelledby": "bookmark-link", "aria-modal": "true"}
     .modal-content
-      .modal-header
+      .modal-header.ps-5
         %button.close{ type: "button", data: { "bs-dismiss": "modal"}, aria: {hidden: "true"}}
           &times;
         #bookmark-link
         %h2.modal-title
           Link to the current search
-      .modal-body
+      .modal-body.px-5
         %p
           You can copy the current search settings to save them
           as a bookmark, or share with other people. Just-press
@@ -25,7 +25,7 @@
             %a.twitter-share-button{ href: "https://twitter.com/share", data: {url: "", text: "Open data from Land Registry", hashtags: "opendata"}}
               Tweet
 
-      .modal-footer
+      .modal-footer.px-5
         .footer-row
           %button.btn.btn-outline-secondary{ type: "button", data: { "bs-dismiss": "modal"} }
             OK

--- a/app/views/ppd/_bookmark_modal.html.haml
+++ b/app/views/ppd/_bookmark_modal.html.haml
@@ -4,7 +4,7 @@
   #bookmark-dialog.modal-dialog{role: "dialog", "aria-labelledby": "bookmark-link", "aria-modal": "true"}
     .modal-content
       .modal-header
-        %button.close{ type: "button", data: {dismiss: "modal"}, aria: {hidden: "true"}}
+        %button.close{ type: "button", data: { "bs-dismiss": "modal"}, aria: {hidden: "true"}}
           &times;
         #bookmark-link
         %h2.modal-title
@@ -27,5 +27,5 @@
 
       .modal-footer
         .footer-row
-          %button.btn.btn-default{ type: "button", data: {dismiss: "modal"} }
+          %button.btn.btn-outline-secondary{ type: "button", data: { "bs-dismiss": "modal"} }
             OK

--- a/app/views/ppd/_help_modal.html.haml
+++ b/app/views/ppd/_help_modal.html.haml
@@ -3,13 +3,13 @@
 #help-modal.modal
   #help-dialog.modal-dialog{role: "dialog", "aria-labelledby": "help-title", "aria-modal": "true"}
     .modal-content
-      .modal-header
+      .modal-header.ps-5
         %button.close{ type: "button", data: { "bs-dismiss": "modal"}, aria: {hidden: "true"}}
           &times;
           #help-title
         %h2.modal-title
           Help and suggestions
-      .modal-body
+      .modal-body.px-5
         %h3 Troubleshooting guide
         %p
           See the
@@ -42,7 +42,7 @@
           please email
           %span.email-address= mail_to(Rails.application.config.contact_email_address)
 
-      .modal-footer
+      .modal-footer.px-5
         .footer-row
           %button.btn.btn-outline-secondary{ type: "button", data: { "bs-dismiss": "modal"} }
             OK

--- a/app/views/ppd/_help_modal.html.haml
+++ b/app/views/ppd/_help_modal.html.haml
@@ -40,7 +40,7 @@
         %p
           If you have additional questions, or you have feedback on this beta service,
           please email
-          .email-address= mail_to(Rails.application.config.contact_email_address)
+          %span.email-address= mail_to(Rails.application.config.contact_email_address)
 
       .modal-footer
         .footer-row

--- a/app/views/ppd/_help_modal.html.haml
+++ b/app/views/ppd/_help_modal.html.haml
@@ -4,7 +4,7 @@
   #help-dialog.modal-dialog{role: "dialog", "aria-labelledby": "help-title", "aria-modal": "true"}
     .modal-content
       .modal-header
-        %button.close{ type: "button", data: {dismiss: "modal"}, aria: {hidden: "true"}}
+        %button.close{ type: "button", data: { "bs-dismiss": "modal"}, aria: {hidden: "true"}}
           &times;
           #help-title
         %h2.modal-title
@@ -44,5 +44,5 @@
 
       .modal-footer
         .footer-row
-          %button.btn.btn-default{ type: "button", data: {dismiss: "modal"} }
+          %button.btn.btn-outline-secondary{ type: "button", data: { "bs-dismiss": "modal"} }
             OK

--- a/app/views/ppd/index.html.haml
+++ b/app/views/ppd/index.html.haml
@@ -170,8 +170,8 @@
               %p.bg-warning
                 Please enter a valid numerical value, or leave blank
 
-      .form-group
-        %label.col-sm-4.control-label.control-label-adjust Date
+      %fieldset.form-group
+        %legend.control-legend.col-sm-4.control-label{ for: "dates" }  Date
         .col-sm-8
           %ul.list-inline
             %li

--- a/app/views/ppd/index.html.haml
+++ b/app/views/ppd/index.html.haml
@@ -3,7 +3,7 @@
 
 = content_for(:title, "Search the price paid dataset")
 
-.row
+.row.px-5
   .col-sm-12
     .pull-right.search-form-actions
       .search-form-action
@@ -15,54 +15,54 @@
           %i.fa.fa-refresh
           reset the form
 
-.row
+.row.px-5
   %h1.col-md-12
     = "#{yield(:title)}:"
   %p.col-md-12
     Enter one or more search terms to locate the property transactions
     you are interested in.
 
-.row
+.row.px-5
   .col-md-12
     =form_tag( {controller: :search, action: :create}, {role: "form", class: "ppd form form-horizontal"} ) do
-      .form-group
-        %label.col-sm-4.control-label{ for: "paon" } Building name or number
-        .col-sm-8
+      .form-group.gx-5
+        %label.col-md-4.control-label{ for: "paon" } Building name or number
+        .col-md-8
           %input#paon.form-control{ type: "text", autocomplete: "on", name: "paon", value: strip_tags(@preferences.param( :paon )), placeholder: "For example: Rose Cottage or 17" }
 
-      .form-group
-        %label.col-sm-4.control-label{ for: "street" } Street
-        .col-sm-8
+      .form-group.gx-5
+        %label.col-md-4.control-label{ for: "street" } Street
+        .col-md-8
           %input#street.form-control{ type: "text", autocomplete: "street-address", name: "street", value: strip_tags(@preferences.param( :street )), placeholder: "Use the full name, or just part of it e.g: Harbour Road or Colston" }
 
-      .form-group
-        %label.col-sm-4.control-label{ for: "town" } Town or city
-        .col-sm-8
+      .form-group.gx-5
+        %label.col-md-4.control-label{ for: "town" } Town or city
+        .col-md-8
           %input#town.form-control{ type: "text", autocomplete: "address-level2", name: "town", value: strip_tags(@preferences.param( :town )), placeholder: "For example: Plymouth" }
 
-      .form-group
-        %label.col-sm-4.control-label{ for: "district" } District
-        .col-sm-8
+      .form-group.gx-5
+        %label.col-md-4.control-label{ for: "district" } District
+        .col-md-8
           %input#district.form-control{ type: "text", autocomplete: "address-level3", name: "district", value: strip_tags(@preferences.param( :district )), placeholder: "For example: City of Westminster" }
 
-      .form-group
-        %label.col-sm-4.control-label{ for: "county" } County
-        .col-sm-8
+      .form-group.gx-5
+        %label.col-md-4.control-label{ for: "county" } County
+        .col-md-8
           %input#county.form-control{ type: "text", autocomplete: "county", name: "county", value: strip_tags(@preferences.param( :county )), placeholder: "For example: Devon" }
 
-      .form-group
-        %label.col-sm-4.control-label{ for: "locality" } Locality
-        .col-sm-8
+      .form-group.gx-5
+        %label.col-md-4.control-label{ for: "locality" } Locality
+        .col-md-8
           %input#locality.form-control{ type: "text", autocomplete: "on", name: "locality", value: strip_tags(@preferences.param( :locality )), placeholder: "For example: Thurloxton" }
 
-      .form-group
-        %label.col-sm-4.control-label{ for: "postcode" } Postcode
-        .col-sm-8
+      .form-group.gx-5
+        %label.col-md-4.control-label{ for: "postcode" } Postcode
+        .col-md-8
           %input#postcode.form-control{ type: "text", autocomplete: "postal-code", name: "postcode", value: strip_tags(@preferences.param( :postcode )), placeholder: "Use a full postcode, or just the first group e.g. PL6 5WS or PL6." }
 
-      %fieldset.form-group
-        %legend.control-legend.col-sm-4.control-label{ for: "ptype" } Property type
-        .col-sm-8
+      %fieldset.form-group.gx-5
+        %legend.control-legend.col-md-4.control-label{ for: "ptype" } Property type
+        .col-md-8
           %ul.list-inline
             %li
               .checkbox
@@ -90,9 +90,9 @@
                   %input{ type: "checkbox", name: "ptype[]", value: "lrcommon:otherPropertyType", checked: @preferences.display_checked?( :ptype, "lrcommon:otherPropertyType") }
                   other
 
-      %fieldset.form-group
-        %legend.control-legend.col-sm-4.control-label{ for: "nb" } New build?
-        .col-sm-8
+      %fieldset.form-group.gx-5
+        %legend.control-legend.col-md-4.control-label{ for: "nb" } New build?
+        .col-md-8
           %ul.list-inline
             %li
               .checkbox
@@ -105,9 +105,9 @@
                   %input{ type: "checkbox", name: "nb[]", value: "false", checked: @preferences.display_checked?( :nb, "false" ) }
                   not new-build
 
-      %fieldset.form-group
-        %legend.control-legend.col-sm-4.control-label{ for: "et" } Estate type
-        .col-sm-8
+      %fieldset.form-group.gx-5
+        %legend.control-legend.col-md-4.control-label{ for: "et" } Estate type
+        .col-md-8
           %ul.list-inline
             %li
               .checkbox
@@ -120,9 +120,9 @@
                   %input{ type: "checkbox", name: "et[]", value: "lrcommon:leasehold", checked: @preferences.display_checked?( :et, "lrcommon:leasehold" ) }
                   leasehold
 
-      %fieldset.form-group
-        %legend.control-legend.col-sm-4.control-label{ for: "tc" } Transaction category
-        .col-sm-8
+      %fieldset.form-group.gx-5
+        %legend.control-legend.col-md-4.control-label{ for: "tc" } Transaction category
+        .col-md-8
           %ul.list-inline
             %li
               .checkbox
@@ -135,11 +135,11 @@
                   %input{ type: "checkbox", name: "tc[]", value: "ppd:additionalPricePaidTransaction", checked: @preferences.display_checked?( :tc, "ppd:additionalPricePaidTransaction" ) }
                   additional
 
-      .form-group
-        %label.col-sm-4.control-label{ for: "min_price" } Minimum price
-        .col-sm-8
+      .form-group.gx-5
+        %label.col-md-4.control-label{ for: "min_price" } Minimum price
+        .col-md-8
           .row
-            .col-sm-4
+            .col-md-4
               .input-group
                 %span.input-group-addon
                   &pound;
@@ -149,14 +149,14 @@
                   value: strip_tags(@preferences.param( :min_price )),
                   spellcheck: false,
                 }
-            .col-sm-8.hidden.validation-warning
+            .col-md-8.hidden.validation-warning
               %p.bg-warning
                 Please enter a valid numerical value, or leave blank
-      .form-group
-        %label.col-sm-4.control-label{ for: "max_price" } Maximum price
-        .col-sm-8
+      .form-group.gx-5
+        %label.col-md-4.control-label{ for: "max_price" } Maximum price
+        .col-md-8
           .row
-            .col-sm-4
+            .col-md-4
               .input-group
                 %span.input-group-addon
                   &pound;
@@ -166,13 +166,13 @@
                   value: strip_tags(@preferences.param( :max_price )),
                   spellcheck: false,
                   }
-            .col-sm-8.hidden.validation-warning
+            .col-md-8.hidden.validation-warning
               %p.bg-warning
                 Please enter a valid numerical value, or leave blank
 
-      %fieldset.form-group
-        %legend.control-legend.col-sm-4.control-label{ for: "dates" }  Date
-        .col-sm-8
+      %fieldset.form-group.gx-5
+        %legend.control-legend.col-md-4.control-label{ for: "dates" }  Date
+        .col-md-8
           %ul.list-inline
             %li
               %div
@@ -185,9 +185,9 @@
                   latest:
                   %input{ type: 'date', name: :max_date, value: @preferences.param( :max_date ), min: "1995-01-01", max: Date.today.iso8601 }
 
-      %fieldset.form-group
-        %legend.control-legend.col-sm-4.control-label{ for: "limit" } How many results?
-        .col-sm-8
+      %fieldset.form-group.gx-5
+        %legend.control-legend.col-md-4.control-label{ for: "limit" } How many results?
+        .col-md-8
           %ul.list-inline
             %li
               .radio

--- a/app/views/ppd_data/_download_options.html.haml
+++ b/app/views/ppd_data/_download_options.html.haml
@@ -7,7 +7,7 @@
   a bug, or that the format requested is not one that is currently supported.
 - else
   .download
-    .row
+    .row.px-5
       .col-md-12
         = render partial: "ppd/workflow_action_buttons", locals: {no_download: true, no_print: true, no_help: true, no_bookmark: true}
         %h1
@@ -15,7 +15,7 @@
 
     .row.spacer
 
-    .row
+    .row.px-5
       .col-md-12
         %table.table
           %thead
@@ -95,7 +95,7 @@
                   %i.fa.fa-eye
                   view SPARQL query
 
-    .row.footnotes
+    .row.footnotes.px-5
       %p
         %a#note1{href:"#note1Ref"}
           %strong Note 1

--- a/app/views/search/_search_results.html.haml
+++ b/app/views/search/_search_results.html.haml
@@ -2,12 +2,17 @@
 = content_for(:title, "Search results")
 
 - sr = @query_command.search_results
-= render partial: "ppd/workflow_action_buttons", locals: {no_results: true, no_print: true}
 
-%h1
-  = yield(:title)
+.row.px-5
+  .col-md-12
+    = render partial: "ppd/workflow_action_buttons", locals: {no_results: true, no_print: true}
 
-.search-summary
+.row.px-5
+  .col-md-12
+  %h1.px-5
+    = yield(:title)
+
+.search-summary.mx-5
   %p
     #{sr&.summarise} by searching for:
   %ul.search-terms.list.list-bullet
@@ -41,7 +46,7 @@
         download the data
     onto your computer.
 
-%ul.list-unstyled.ppd-results
+%ul.list-unstyled.ppd-results.mx-5
   - result = nil
   - sr&.each_property_address do |results|
     - previous_result = result

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,20 +42,23 @@ module PpdExplorer
   end
 end
 
-# Monkey-patch the bit of Rails that emits the start-up log message, so that it
-# is written out in JSON format that our combined logging service can handle
+# Monkey-patch the bit of Rails that emits the start-up log message, so
+# that it is written out in JSON format that our combined logging
+# service can handle
 module Rails
   # :nodoc:
   module Command
     # :nodoc:
     class ServerCommand
       def print_boot_information(server, url)
-        msg = {
+        msg = "Starting #{server} Rails #{Rails.version} in #{Rails.env}"
+        msg += " on #{url}" if url
+        info = {
           ts: DateTime.now.utc.strftime('%FT%T.%3NZ'),
           level: 'INFO',
-          message: "Starting #{server} Rails #{Rails.version} in #{Rails.env} #{url}"
+          message: msg
         }
-        say msg.to_json
+        say info.to_json
       end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,9 @@ module PpdExplorer
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    # Quiet SASS deprecation warnings coming from dependencies
+    config.sass.quiet_deps = true
+
     config.assets.paths << Rails.root.join('app/assets/fonts')
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,6 @@
 require File.expand_path('boot', __dir__)
 
 # Pick the frameworks you want:
-# require "active_record/railtie"
 require 'action_controller/railtie'
 require 'action_mailer/railtie'
 require 'sprockets/railtie'
@@ -37,7 +36,10 @@ module PpdExplorer
 
     # Quiet SASS deprecation warnings coming from dependencies
     config.sass.quiet_deps = true
-
+    # Silence @import deprecation warnings during migration to @use/@forward
+    # See: https://sass-lang.com/d/import
+    config.sass.silence_deprecations = ['import']
+    # Add fonts path to asset pipeline
     config.assets.paths << Rails.root.join('app/assets/fonts')
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,9 @@ PpdExplorer::Application.configure do
   # Don't print a log message every time an asset file is loaded
   config.assets.quiet = true
 
+  # Enable SASS source maps in development for easier debugging
+  config.sass.inline_source_maps = true
+
   # Tag rails logs with useful information
   config.log_tags = %i[subdomain request_id request_method]
   # When sync mode is true, all output is immediately flushed to the underlying

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,6 +37,12 @@ PpdExplorer::Application.configure do
   # yet still be able to expire them through the digest params.
   config.assets.digest = true
 
+  # `config.sass.style` has been deprecated in favor of `config.assets.css_compressor`
+  # Set SASS output style to compressed for smaller file sizes
+  config.sass.style = :compressed
+  # SASS source maps are disabled in production for performance
+  config.sass.inline_source_maps = false
+
   # `config.assets.precompile` and `config.assets.version` have moved to
   # config/initializers/assets.rb
 

--- a/config/initializers/autoprefixer.rb
+++ b/config/initializers/autoprefixer.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Configure Autoprefixer to generate source maps for easier debugging of CSS
+# See: https://github.com/tablecheck/dartsass-sprockets/issues/23#issuecomment-2408131105
+class AutoprefixerWithSourcemap < AutoprefixerRails::Sprockets
+  def self.run(filename, css)
+    output = "#{filename.chomp(File.extname(filename))}.css"
+
+    # If you want this nice an generic, you could check `css` for the presence
+    # of an inline source map, and set the `map` argument based on that
+    # instead of always setting it to `true`.
+    result = @processor.process(css, from: filename, to: output, map: true)
+
+    result.warnings.each do |warning|
+      warn "autoprefixer: #{warning}"
+    end
+
+    result.css
+  end
+
+  def self.use_bundle_processor?
+    ::Sprockets::VERSION.to_f >= 4
+  end
+
+  def self.install(env)
+    if use_bundle_processor?
+      env.register_bundle_processor('text/css', self)
+    else
+      env.register_postprocessor('text/css', self)
+    end
+  end
+
+  def self.uninstall(env)
+    if use_bundle_processor?
+      env.unregister_bundle_processor('text/css', self)
+    else
+      env.unregister_postprocessor('text/css', self)
+    end
+  end
+end
+
+Rails.application.config.assets.configure do |env|
+  AutoprefixerRails.uninstall(env)
+  AutoprefixerWithSourcemap.register_processor(AutoprefixerRails.processor({}))
+  AutoprefixerWithSourcemap.install(env)
+end


### PR DESCRIPTION
**Deploy Target:** Prod (Release)

> [!TIP]
> This is a release PR. All changes have been reviewed and merged
> into `dev`. Approval confirms the version and changes are ready for testing
> before production release.

## Summary

Modernised the front-end stack by migrating from deprecated Ruby Sass
(`sass-rails` / `bootstrap-sass`) to Dart Sass with Bootstrap 5 support,
resolved gem versioning warnings, and improved UI/UX across the application.

Relates to #308, #309, #312

## Changes

- Replaced `bootstrap-sass` with `bootstrap` gem for Dart Sass compatibility
- Added `dartsass-sprockets` gem for Rails integration
- Updated stylesheets to use Sass modules (`@use 'sass:color'` instead of deprecated `lighten`)
- Removed `sass-rails` gem and deprecated dependencies
- Modernised modals and forms to Bootstrap 5 notation (`data-bs-dismiss` attributes)
- Converted form groups to semantic fieldsets for improved accessibility
- Enhanced error page layout with additional status messages (403, 422)
- Improved page layout padding and form spacing
- Enhanced action buttons responsiveness with flexbox
- Added cookie banner styling using Bootstrap conventions
- Added Popper.js dependency for Bootstrap functionality
- Added Autoprefixer initialiser for source map support
- Resolved open-ended gem versioning warnings with explicit version minimums for Faraday dependencies
- Updated `faraday-follow_redirects` to 0.4.0
- Updated `lr_common_styles` gem to v3.0.0 (Bootstrap 5)
- Updated `data_services_api` gem to v1.6.1
- Enabled Sass source maps in development for easier front-end debugging
- Added `update` Makefile target to check outdated dependencies
- Streamlined Makefile with inline help documentation
- Cleaned up startup log output formatting
- Removed duplicated `_search-form.scss` partial (consolidated into `_workflow-actions.scss`)

## Breaking Changes

This release updates Bootstrap from 3.x to 5.x via the `lr_common_styles` gem
v3.0.0. Ensure any downstream dependencies or custom styling are compatible
with Bootstrap 5.


**Full Changelog**: https://github.com/epimorphics/ppd-explorer/compare/v2.2.3...v2.3.0