### PR TITLE
ci: add verify workflow and gate publish on passing checks

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -1,0 +1,11 @@
+name: Setup Ruby Environment
+description: Shared setup for Ruby scripts, Bundler, and Rails tooling
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: .ruby-version
+        bundler-cache: true

--- a/.github/workflows/publish-deploy.yml
+++ b/.github/workflows/publish-deploy.yml
@@ -1,10 +1,63 @@
 name: "Build & Publish Docker Image"
 on:
   workflow_dispatch: {}
-  push: {}
+  pull_request:
+    branches:
+      - dev
+      - preprod
+      - prod
+    paths:
+      # Image definition and entrypoint
+      - 'Dockerfile'
+      - 'entrypoint.sh'
+      - 'Makefile'
+      # Ruby dependencies
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '.ruby-version'
+      - '.bundle/**'
+      # Rails application
+      - 'config.ru'
+      - 'Rakefile'
+      - 'app/**'
+      - 'bin/**'
+      - 'config/**'
+      - 'lib/**'
+      - 'public/**'
+      # Workflow itself
+      - '.github/workflows/**'
+  push:
+    branches:
+      - dev
+      - preprod
+      - prod
+    paths:
+      # Image definition and entrypoint
+      - 'Dockerfile'
+      - 'entrypoint.sh'
+      - 'Makefile'
+      # Ruby dependencies
+      - 'Gemfile'
+      - 'Gemfile.lock'
+      - '.ruby-version'
+      - '.bundle/**'
+      # Rails application
+      - 'config.ru'
+      - 'Rakefile'
+      - 'app/**'
+      - 'bin/**'
+      - 'config/**'
+      - 'lib/**'
+      - 'public/**'
+      # Workflow itself
+      - '.github/workflows/**'
 
 jobs:
+  verify-code:
+    uses: ./.github/workflows/verify.yml
+    secrets: inherit
   publish:
+    needs: verify-code
     uses:  "epimorphics/github-workflows/.github/workflows/publish.yml@v2"
     secrets:
       # Repostory specific

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,43 @@
+name: 'Verify Code'
+
+permissions:
+  contents: read
+  packages: read
+
+on:
+  workflow_call: {}
+
+jobs:
+  lint-ruby:
+    name: RuboCop Lint
+    env:
+      BUNDLE_RUBYGEMS__PKG__GITHUB__COM: "x-access-token:${{ secrets.GITHUB_TOKEN }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby Environment
+        uses: ./.github/actions/setup-ruby
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run RuboCop
+        run: bundle exec rubocop --parallel
+
+  test-ruby:
+    name: Rails Test Suite
+    env:
+      BUNDLE_RUBYGEMS__PKG__GITHUB__COM: "x-access-token:${{ secrets.GITHUB_TOKEN }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby Environment
+        uses: ./.github/actions/setup-ruby
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Rails tests
+        run: bin/rails test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ plugins:
 AllCops:
   Exclude:
     - "node_modules/**/*"
+    - "vendor/**/*"
     - "Gemfile"
   NewCops: enable
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -158,7 +158,7 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
   # @param [exc] exp the exception that caused the error
   # @return [ActiveSupport::Notifications::Event] provides an object-oriented
   # interface to the event
-  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
   def instrument_internal_error(exc, status = nil)
     err = {
       message: exc&.message || exc,
@@ -179,5 +179,5 @@ class ApplicationController < ActionController::Base # rubocop:disable Metrics/C
     # Return the event id for the internal error event
     sevent&.event_id
   end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize
 end

--- a/app/controllers/ppd_data_controller.rb
+++ b/app/controllers/ppd_data_controller.rb
@@ -3,6 +3,7 @@
 # Controller for downloading data
 class PpdDataController < ApplicationController
   include DsapiTurtleFormatter
+
   MAX_DOWNLOAD_RESULTS = 1_000_000
 
   # Above this number of results in a resultset, we write the CSV to a file first

--- a/app/helpers/postcode_helper.rb
+++ b/app/helpers/postcode_helper.rb
@@ -30,25 +30,22 @@ module PostcodeHelper
   #   format_postcode("L1 8JQ")  => "L1 8JQ" (already formatted)
   #   format_postcode("L18")     => "L18" (ambiguous, unchanged)
   def format_postcode(postcode)
-    # Preserve nil input, and normalise whitespace-only input to empty string
     return nil if postcode.nil?
 
-    cleaned = postcode.strip
+    cleaned = postcode.strip.upcase
     return '' if cleaned.empty?
+    return cleaned if cleaned.include?(' ')
 
-    # Already has a space - normalise and return
-    return cleaned.upcase if cleaned.include?(' ')
+    insert_space(cleaned)
+  end
 
-    # Clean and prepare for formatting
-    cleaned = cleaned.upcase
-    # Get length of cleaned postcode
-    length = cleaned.length
-    # Only format if it's within the valid full postcode range (5-7 chars)
-    if length >= MIN_FULL_POSTCODE_LENGTH && length <= MAX_FULL_POSTCODE_LENGTH
-      cleaned.insert(-INWARD_CODE_LENGTH - 1, ' ')
-    else
-      # Too short or too long - return as-is (could be partial or invalid)
-      cleaned
+  private
+
+  def insert_space(postcode)
+    unless postcode.length.between?(MIN_FULL_POSTCODE_LENGTH, MAX_FULL_POSTCODE_LENGTH)
+      return postcode
     end
+
+    postcode.dup.insert(-INWARD_CODE_LENGTH - 1, ' ')
   end
 end

--- a/app/lib/logging_helper.rb
+++ b/app/lib/logging_helper.rb
@@ -3,7 +3,7 @@
 # :nodoc:
 class LoggingHelper
   def self.log_request(fields, type = 'info') # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-    puts "\n" if Rails.env.development? && Rails.logger.debug?
+    Rails.logger.debug "\n" if Rails.env.development? && Rails.logger.debug?
     # Extract service and params from fields hash
     service = fields[:service] if fields[:service].respond_to?(:data_api)
     params = fields[:params] if fields[:params].presence

--- a/app/models/filter_aspect.rb
+++ b/app/models/filter_aspect.rb
@@ -7,7 +7,7 @@ class FilterAspect < Aspect
   end
 
   def add_filter_clause(query, preferences)
-    if is_uri_value?
+    if uri_value?
       query.eq_any_uri(aspect_property, preference_value(preferences))
     else
       query.eq_any_value(aspect_property, preference_value(preferences), type: value_type)
@@ -18,7 +18,7 @@ class FilterAspect < Aspect
     option(:operator)
   end
 
-  def is_uri_value? # rubocop:disable Naming/PredicateName
+  def uri_value?
     option(:uri_value)
   end
 
@@ -45,7 +45,7 @@ class FilterAspect < Aspect
   end
 
   def generate_filter_value_label(value)
-    value_label = is_uri_value? ? uri_as_label(value) : value.to_s
+    value_label = uri_value? ? uri_as_label(value) : value.to_s
     "#{key_as_label} is #{value_label}"
   end
 

--- a/app/models/query_command.rb
+++ b/app/models/query_command.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Command object providing a service for driving the DsAPI
-class QueryCommand < DataService # rubocop:disable Metrics/ClassLength
+class QueryCommand < DataService
   include TurtleFormatter
 
   attr_reader :all_results, :search_results, :error_message
@@ -111,7 +111,7 @@ class QueryCommand < DataService # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def load_query_results(options = {}) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+  def load_query_results(options = {}) # rubocop:disable Metrics/MethodLength
     ppd = dataset(:ppd)
     query = assemble_query
     limit = query_limit
@@ -180,7 +180,7 @@ class QueryCommand < DataService # rubocop:disable Metrics/ClassLength
   def add_count_information(ppd, count_query)
     count_result = ppd.query(count_query)
     count = count_result.first['ppd:count']
-    @search_results.query_count("#{count}#{count == COUNT_LIMIT ? ' or more' : ''}")
+    @search_results.query_count("#{count}#{' or more' if count == COUNT_LIMIT}")
   end
 
   def success?

--- a/app/models/search_result.rb
+++ b/app/models/search_result.rb
@@ -122,7 +122,7 @@ class SearchResult # rubocop:disable Metrics/ClassLength
   end
 
   def new_build
-    { label: "#{new_build? ? '' : 'not '}new-build" }
+    { label: "#{'not ' unless new_build?}new-build" }
   end
 
   def new_build_formatted
@@ -236,7 +236,7 @@ class SearchResult # rubocop:disable Metrics/ClassLength
 
     paon_tokens = format_paon_elements(paon)
     comma_not_needed = paon_tokens.last =~ /\d/
-    fields << "#{paon_tokens.join(' ')}#{comma_not_needed ? '' : ','}"
+    fields << "#{paon_tokens.join(' ')}#{',' unless comma_not_needed}"
   end
 
   def format_paon_elements(paon)

--- a/app/models/search_results.rb
+++ b/app/models/search_results.rb
@@ -3,6 +3,7 @@
 # Encapsulates a collection of results from a user query
 class SearchResults
   include ActionView::Helpers::TextHelper
+
   attr_reader :index, :transactions, :max_results_limit_hit
 
   DEFAULT_MAX_RESULTS = 5000
@@ -70,25 +71,25 @@ class SearchResults
   end
 
   # TODO: DRY
-  def traverse_in_sort_order(index, &block)
+  def traverse_in_sort_order(index, &)
     index.keys.sort.each do |key|
       v = index[key]
 
       if v.is_a?(Hash)
-        traverse_in_sort_order(v, &block)
+        traverse_in_sort_order(v, &)
       else
-        traverse_in_date_order(v, &block)
+        traverse_in_date_order(v, &)
       end
     end
   end
 
   # TODO: DRY
-  def traverse_property_addresses(index, &block)
+  def traverse_property_addresses(index, &)
     index.keys.sort.each do |key|
       v = index[key]
 
       if v.is_a?(Hash)
-        traverse_property_addresses(v, &block)
+        traverse_property_addresses(v, &)
       else
         yield v.sort!.reverse
       end

--- a/app/models/search_term.rb
+++ b/app/models/search_term.rb
@@ -18,7 +18,7 @@ class SearchTerm
   end
 
   def form_name
-    "#{name}#{@values ? [] : ''}"
+    "#{name}#{[] if @values}"
   end
 
   def form_value

--- a/app/models/user_preferences.rb
+++ b/app/models/user_preferences.rb
@@ -137,9 +137,8 @@ class UserPreferences
   # ambiguity with partial postcodes like "L18" which could be
   # outward code "L18" or sector "L1 8"
   def format_postcode_param!
-    return unless @params[:postcode].present?
+    return if @params[:postcode].blank?
 
     @params[:postcode] = format_postcode(@params[:postcode])
   end
-
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -8,9 +8,9 @@ Rails.application.reloader.to_prepare do
     config.breadcrumbs_logger = %i[sentry_logger monotonic_active_support_logger http_logger]
     # * The DSN tells the SDK where to send events.
     # ! By default, events will be sent to Sentry in all environments.
-    #! If you don't want to send events in a specific environment,
-    #! you can unset the SENTRY_DSN [SENTRY_API_KEY] variable in that environment.
-    config.dsn = ENV['SENTRY_API_KEY']
+    # ! If you don't want to send events in a specific environment,
+    # ! you can unset the SENTRY_DSN [SENTRY_API_KEY] variable in that environment.
+    config.dsn = ENV.fetch('SENTRY_API_KEY', nil)
     # ! Only report errors in these environments:
     config.enabled_environments = %w[production prod preprod dev]
     # ! Ignore exceptions that are not useful to us

--- a/test/controllers/ppd_data_controller_test.rb
+++ b/test/controllers/ppd_data_controller_test.rb
@@ -8,7 +8,7 @@ class PpdDataControllerTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
   include Capybara::Minitest::Assertions
 
-  describe 'PpdDataController' do # rubocop:disable Metrics/BlockLength
+  describe 'PpdDataController' do
     let(:base_params) do
       {
         et: ['lrcommon:freehold', 'lrcommon:leasehold'],

--- a/test/lib/auto_extend_hash_test.rb
+++ b/test/lib/auto_extend_hash_test.rb
@@ -12,8 +12,8 @@ class AutoExtendHashTest < ActiveSupport::TestCase
       it 'should create a hash that auto-extends' do
         auto_hash = AutoExtendHash.new
 
-        refute auto_hash.key?(:foo)
-        refute_nil auto_hash[:foo]
+        assert_not auto_hash.key?(:foo)
+        assert_not_nil auto_hash[:foo]
         assert auto_hash.key?(:foo)
       end
     end
@@ -22,7 +22,7 @@ class AutoExtendHashTest < ActiveSupport::TestCase
       it 'should allow assignment to a new key like a normal hash' do
         auto_hash = AutoExtendHash.new
 
-        refute auto_hash.key?(:foo)
+        assert_not auto_hash.key?(:foo)
         auto_hash[:foo] = :bar
         assert auto_hash.key?(:foo)
         assert_equal :bar, auto_hash[:foo]
@@ -40,12 +40,12 @@ class AutoExtendHashTest < ActiveSupport::TestCase
       it 'should allow an existing hash to be converted to auto-extend behaviour' do
         orig = {}
 
-        refute orig.key?(:foo)
+        assert_not orig.key?(:foo)
         orig[:foo]
-        refute orig.key?(:foo)
+        assert_not orig.key?(:foo)
 
         AutoExtendHash.auto_extend(orig)
-        refute orig.key?(:foo)
+        assert_not orig.key?(:foo)
         orig[:foo]
         assert orig.key?(:foo)
       end
@@ -54,7 +54,7 @@ class AutoExtendHashTest < ActiveSupport::TestCase
         orig = {}
         AutoExtendHash.auto_extend(orig)
 
-        refute orig.key?(:foo)
+        assert_not orig.key?(:foo)
         orig[:foo][:bar] = 'wombles'
         assert_equal 'wombles', orig[:foo][:bar]
       end
@@ -63,7 +63,7 @@ class AutoExtendHashTest < ActiveSupport::TestCase
         orig = { foo: {} }
         AutoExtendHash.auto_extend(orig)
 
-        refute orig[:foo].key?(:bar)
+        assert_not orig[:foo].key?(:bar)
         orig[:foo][:bar][:fubar] = 'wombles'
         assert_equal 'wombles', orig[:foo][:bar][:fubar]
       end
@@ -72,7 +72,7 @@ class AutoExtendHashTest < ActiveSupport::TestCase
         orig = Hash.new { |hash, key| hash[key] = :chewbacca }
         AutoExtendHash.auto_extend(orig)
 
-        refute orig.key?(:foo)
+        assert_not orig.key?(:foo)
         assert_equal :chewbacca, orig[:foo]
       end
     end

--- a/test/models/aspect_test.rb
+++ b/test/models/aspect_test.rb
@@ -20,12 +20,12 @@ describe 'Aspect' do
   it 'should check just the key for presence in the parameters' do
     aspect = Aspect.new(:street, 'foo:bar')
     assert aspect.present?(UserPreferences.new(params_object('street' => 'bar')))
-    refute aspect.present?(UserPreferences.new(params_object('town' => 'bar')))
+    assert_not aspect.present?(UserPreferences.new(params_object('town' => 'bar')))
   end
 
   it 'should not be present if all values are given' do
     aspect = Aspect.new(:street, 'foo:bar', values: %w[a b c])
-    refute aspect.present?(UserPreferences.new(params_object('street' => %w[a b c])))
+    assert_not aspect.present?(UserPreferences.new(params_object('street' => %w[a b c])))
   end
 
   it 'should return a preference value' do

--- a/test/models/aspect_test.rb
+++ b/test/models/aspect_test.rb
@@ -20,12 +20,12 @@ describe 'Aspect' do
   it 'should check just the key for presence in the parameters' do
     aspect = Aspect.new(:street, 'foo:bar')
     assert aspect.present?(UserPreferences.new(params_object('street' => 'bar')))
-    assert_not aspect.present?(UserPreferences.new(params_object('town' => 'bar')))
+    refute aspect.present?(UserPreferences.new(params_object('town' => 'bar')))
   end
 
   it 'should not be present if all values are given' do
     aspect = Aspect.new(:street, 'foo:bar', values: %w[a b c])
-    assert_not aspect.present?(UserPreferences.new(params_object('street' => %w[a b c])))
+    refute aspect.present?(UserPreferences.new(params_object('street' => %w[a b c])))
   end
 
   it 'should return a preference value' do

--- a/test/models/user_preferences_test.rb
+++ b/test/models/user_preferences_test.rb
@@ -17,19 +17,19 @@ describe 'UserPreferences' do
   it 'should report a parameter as present, or not' do
     prefs = UserPreferences.new(params_object('street' => 'bar'))
     assert prefs.present?(:street)
-    refute prefs.present?(:town)
+    assert_not prefs.present?(:town)
   end
 
   it 'should report a parameter as present with a given value, or not' do
     prefs = UserPreferences.new(params_object('street' => 'bar'))
     assert prefs.present?(:street, 'bar')
-    refute prefs.present?(:street, 'blam')
+    assert_not prefs.present?(:street, 'blam')
   end
 
   it 'should report a parameter as present, with a list of values, or not' do
     prefs = UserPreferences.new(params_object('nb' => %w[true false]))
     assert prefs.present?(:nb, 'true')
     assert prefs.present?(:nb, 'false')
-    refute prefs.present?(:nb, 'flimflam')
+    assert_not prefs.present?(:nb, 'flimflam')
   end
 end

--- a/test/models/user_preferences_test.rb
+++ b/test/models/user_preferences_test.rb
@@ -17,19 +17,19 @@ describe 'UserPreferences' do
   it 'should report a parameter as present, or not' do
     prefs = UserPreferences.new(params_object('street' => 'bar'))
     assert prefs.present?(:street)
-    assert_not prefs.present?(:town)
+    refute prefs.present?(:town)
   end
 
   it 'should report a parameter as present with a given value, or not' do
     prefs = UserPreferences.new(params_object('street' => 'bar'))
     assert prefs.present?(:street, 'bar')
-    assert_not prefs.present?(:street, 'blam')
+    refute prefs.present?(:street, 'blam')
   end
 
   it 'should report a parameter as present, with a list of values, or not' do
     prefs = UserPreferences.new(params_object('nb' => %w[true false]))
     assert prefs.present?(:nb, 'true')
     assert prefs.present?(:nb, 'false')
-    assert_not prefs.present?(:nb, 'flimflam')
+    refute prefs.present?(:nb, 'flimflam')
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,14 +35,16 @@ require 'minitest/reporters'
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
 # Include Capybara DSL in test classes
-class ActionDispatch::IntegrationTest
-  include Capybara::DSL
-  include Capybara::Minitest::Assertions
+module ActionDispatch
+  class IntegrationTest
+    include Capybara::DSL
+    include Capybara::Minitest::Assertions
 
-  def teardown
-    super
-    Capybara.reset_sessions!
-    Capybara.use_default_driver
+    def teardown
+      super
+      Capybara.reset_sessions!
+      Capybara.use_default_driver
+    end
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,7 @@ require 'minitest/rails'
 
 # Load spec functionality without conflicting parallelize support
 require 'minitest/spec'
+Minitest::Spec.include ActiveSupport::Testing::Assertions
 
 require 'mocha/minitest'
 require 'json_expressions/minitest'


### PR DESCRIPTION
- Adds a `verify` reusable workflow that runs RuboCop and the Rails test suite, and gates the publish/deploy pipeline on it passing
- Fixes RuboCop violations across the codebase (formatting, style, frozen string literals)
- Excludes `vendor/` from RuboCop to prevent obsolete cop references in bundled gems from failing the lint check
- Makes `assert_not` available in Minitest spec-style (`describe`/`it`) tests by including `ActiveSupport::Testing::Assertions` into `Minitest::Spec`