### PR TITLE
chore: add ERROR-level logging for api connection failures in `ApiPrometheusSubscriber`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added log-lines to `ApiPrometheusSubscriber` on connection failure and service exception events [#614](https://github.com/epimorphics/ukhpi/issues/614).
+- Added an `ApiPrometheusSubscriberTest` [#614](https://github.com/epimorphics/ukhpi/issues/614).
+
 ## [2.3.2] - 2026-05
 
 ### Added

--- a/app/subscribers/api_prometheus_subscriber.rb
+++ b/app/subscribers/api_prometheus_subscriber.rb
@@ -1,6 +1,4 @@
-# frozen_string_literal: true
-
-# Subscribe to :data_api events
+# Subscribe to :api events
 class ApiPrometheusSubscriber < ActiveSupport::Subscriber
   attach_to :api
 
@@ -16,23 +14,39 @@ class ApiPrometheusSubscriber < ActiveSupport::Subscriber
                       .increment(labels: { result: 'success' })
     Prometheus::Client.registry
                       .get(:api_response_times)
-                      .observe(duration)
+                      .observe(duration.to_i)
   end
 
   def connection_failure(event)
-    message = event.payload[:exception]
+    exception = event.payload[:exception]
     Prometheus::Client.registry
                       .get(:api_requests)
                       .increment(labels: { result: 'failure' })
     Prometheus::Client.registry
                       .get(:api_connection_failure)
-                      .increment(labels: { message: message.to_s })
+                      .increment(labels: { message: exception.to_s })
+
+    Rails.logger.error(
+      "API connection failure: #{exception.message} - #{exception.class.name}",
+      {
+        request_status: 'error',
+        status: 503
+      }
+    )
   end
 
   def service_exception(event)
-    message = event.payload[:exception]
+    exception = event.payload[:exception]
     Prometheus::Client.registry
                       .get(:api_service_exception)
-                      .increment(labels: { message: message.to_s })
+                      .increment(labels: { message: exception.to_s })
+
+    Rails.logger.error(
+      "API service exception: #{exception.message} - #{exception.class.name}",
+      {
+        request_status: 'error',
+        status: exception.respond_to?(:status) ? exception.status : 502
+      }
+    )
   end
 end

--- a/app/subscribers/api_prometheus_subscriber.rb
+++ b/app/subscribers/api_prometheus_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Subscribe to :api events
 class ApiPrometheusSubscriber < ActiveSupport::Subscriber
   attach_to :api

--- a/test/subscribers/api_prometheus_subscriber_test.rb
+++ b/test/subscribers/api_prometheus_subscriber_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Unit tests on the ApiPrometheusSubscriber class

--- a/test/subscribers/api_prometheus_subscriber_test.rb
+++ b/test/subscribers/api_prometheus_subscriber_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+# Unit tests on the ApiPrometheusSubscriber class
+class ApiPrometheusSubscriberTest < ActiveSupport::TestCase
+  describe 'ApiPrometheusSubscriber' do
+    describe '#connection_failure' do
+      it 'should increment the failure counters and log an error' do
+        exception = Faraday::ConnectionFailed.new('Failed to open TCP connection to data-api:8080')
+        event = stub(payload: { exception: exception })
+
+        Prometheus::Client.registry.get(:api_requests).expects(:increment).with(labels: { result: 'failure' })
+        Prometheus::Client.registry.get(:api_connection_failure).expects(:increment)
+                          .with(labels: { message: exception.to_s })
+        Rails.logger.expects(:error).with(
+          "API connection failure: #{exception.message} - Faraday::ConnectionFailed",
+          { request_status: 'error', status: 503 }
+        )
+
+        ApiPrometheusSubscriber.new.connection_failure(event)
+      end
+    end
+
+    describe '#service_exception' do
+      it 'should increment the exception counter and log an error' do
+        exception = StandardError.new('Unexpected response from data-api')
+        event = stub(payload: { exception: exception })
+
+        Prometheus::Client.registry.get(:api_service_exception).expects(:increment)
+                          .with(labels: { message: exception.to_s })
+        Rails.logger.expects(:error).with(
+          "API service exception: #{exception.message} - StandardError",
+          { request_status: 'error', status: 502 }
+        )
+
+        ApiPrometheusSubscriber.new.service_exception(event)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addresses #338
