### PR TITLE
fix(ppd): correct autocomplete tokens for address fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected invalid/inconsistent `autocomplete` tokens on the County, District, and Town search fields to use valid, semantically ordered `address-level` values [#341](https://github.com/epimorphics/ppd-explorer/issues/341).
+
 ## [2.3.3] - 2026-07-14
 
 ### Added

--- a/app/views/ppd/index.html.haml
+++ b/app/views/ppd/index.html.haml
@@ -38,17 +38,17 @@
       .form-group.gx-5
         %label.col-md-4.control-label{ for: "town" } Town or city
         .col-md-8
-          %input#town.form-control{ type: "text", autocomplete: "address-level2", name: "town", value: strip_tags(@preferences.param( :town )), placeholder: "For example: Plymouth" }
+          %input#town.form-control{ type: "text", autocomplete: "address-level3", name: "town", value: strip_tags(@preferences.param( :town )), placeholder: "For example: Plymouth" }
 
       .form-group.gx-5
         %label.col-md-4.control-label{ for: "district" } District
         .col-md-8
-          %input#district.form-control{ type: "text", autocomplete: "address-level3", name: "district", value: strip_tags(@preferences.param( :district )), placeholder: "For example: City of Westminster" }
+          %input#district.form-control{ type: "text", autocomplete: "address-level2", name: "district", value: strip_tags(@preferences.param( :district )), placeholder: "For example: City of Westminster" }
 
       .form-group.gx-5
         %label.col-md-4.control-label{ for: "county" } County
         .col-md-8
-          %input#county.form-control{ type: "text", autocomplete: "county", name: "county", value: strip_tags(@preferences.param( :county )), placeholder: "For example: Devon" }
+          %input#county.form-control{ type: "text", autocomplete: "address-level1", name: "county", value: strip_tags(@preferences.param( :county )), placeholder: "For example: Devon" }
 
       .form-group.gx-5
         %label.col-md-4.control-label{ for: "locality" } Locality


### PR DESCRIPTION
- Fix invalid autocomplete="county" and reorder County/District/Town address-level tokens to match UK admin hierarchy
- Update changelog

Relates to this ticket - https://github.com/epimorphics/ppd-explorer/issues/341
